### PR TITLE
Fix critical bugs that could crash server or cause panics

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -63,7 +63,10 @@ func (b *BackendService) run(ctx context.Context) error {
 	defer source.Close()
 
 	// Allowed SPIFFE ID
-	clientID := spiffeid.RequireFromString(b.spiffeAuthz)
+	clientID, err := spiffeid.FromString(b.spiffeAuthz)
+	if err != nil {
+		return fmt.Errorf("invalid SPIFFE ID configuration: %w", err)
+	}
 
 	// Create a `tls.Config` to allow mTLS connections, and verify that presented certificate has SPIFFE ID `spiffe://example.org/client`
 	tlsConfig := tlsconfig.MTLSServerConfig(source, source, tlsconfig.AuthorizeID(clientID))
@@ -86,7 +89,9 @@ func (b *BackendService) rootHandler(w http.ResponseWriter, r *http.Request) {
 	currentTime := time.Now()
 	formattedTime := currentTime.Format("02/01/06 15:04:05")
 	text := fmt.Sprintf("%s: Successfully connected to the backend service!!!", formattedTime)
-	_, _ = io.WriteString(w, text)
+	if _, err := io.WriteString(w, text); err != nil {
+		log.Printf("Error writing response: %v", err)
+	}
 	requestorSPIFFEID, err := spiffetls.PeerIDFromConnectionState(*r.TLS)
 	if err != nil {
 		log.Printf("Wasn't able to determine the SPIFFE ID of the requestor: %v", err)

--- a/pkg/customer/mtls.go
+++ b/pkg/customer/mtls.go
@@ -52,7 +52,11 @@ func mTLSCall(w http.ResponseWriter, spiffeAuthZ string, backendAddress string) 
 	defer source.Close()
 
 	// Allowed SPIFFE ID
-	serverID := spiffeid.RequireFromString(spiffeAuthZ)
+	serverID, err := spiffeid.FromString(spiffeAuthZ)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("Invalid SPIFFE ID configuration: %v", err), http.StatusInternalServerError)
+		return
+	}
 
 	// Create a `tls.Config` to allow mTLS connections, and verify that presented certificate has SPIFFE ID.
 	tlsConfig := tlsconfig.MTLSClientConfig(source, source, tlsconfig.AuthorizeID(serverID))

--- a/pkg/customer/postgresql.go
+++ b/pkg/customer/postgresql.go
@@ -84,7 +84,8 @@ func (c *CustomerService) postgreSQLRetrievalHandler(w http.ResponseWriter, r *h
 	// Log errors if we found one when iterating over the rows.
 	err = rows.Err()
 	if err != nil {
-		log.Fatalf("Error iterating rows: %v", err)
+		log.Printf("Error iterating rows: %v", err)
+		http.Error(w, "Database error", http.StatusInternalServerError)
 		return
 	}
 }
@@ -151,7 +152,7 @@ func (c *CustomerService) setupPostgreSQLConnection() (*sql.DB, error) {
 	// Parse the PostgreSQL config settings
 	config, err := pgx.ParseConfig(connStr)
 	if err != nil {
-		log.Fatalf("Unable to parse connection string: %v", err)
+		return nil, fmt.Errorf("unable to parse connection string: %v", err)
 	}
 
 	// Set the TLS config to the SPIFFE TLS config that we retrieved earlier from the Workload API.

--- a/pkg/customer/webpage.go
+++ b/pkg/customer/webpage.go
@@ -18,6 +18,7 @@ package customer
 import (
 	"embed"
 	"io/fs"
+	"log"
 	"net/http"
 )
 
@@ -33,5 +34,7 @@ func (c *CustomerService) webpageHandler(w http.ResponseWriter, r *http.Request)
 	}
 
 	w.Header().Set("Content-Type", "text/html")
-	w.Write(data)
+	if _, err := w.Write(data); err != nil {
+		log.Printf("Error writing response: %v", err)
+	}
 }

--- a/pkg/httpservice/httpservice.go
+++ b/pkg/httpservice/httpservice.go
@@ -29,11 +29,11 @@ type HTTPService struct {
 
 // Main function that creates the httpbackend server and starts it. This is called from the CLI.
 func StartServer(serverAddress string) {
-	HTTPService := HTTPService{
+	svc := HTTPService{
 		serverAddress: serverAddress,
 	}
 
-	if err := HTTPService.run(); err != nil {
+	if err := svc.run(); err != nil {
 		log.Fatal(err)
 	}
 }
@@ -59,5 +59,7 @@ func (h *HTTPService) rootHandler(w http.ResponseWriter, r *http.Request) {
 	currentTime := time.Now()
 	formattedTime := currentTime.Format("02/01/06 15:04:05")
 	text := fmt.Sprintf("%s: Successfully connected to the HTTP service!!!", formattedTime)
-	_, _ = io.WriteString(w, text)
+	if _, err := io.WriteString(w, text); err != nil {
+		log.Printf("Error writing response: %v", err)
+	}
 }


### PR DESCRIPTION
## Summary
- Replace `log.Fatalf` with proper error handling in `postgresql.go` (prevents server crashes)
- Change `spiffeid.RequireFromString` to `FromString` with error handling (prevents panics)
- Fix variable shadowing in `httpservice.go` (`HTTPService := HTTPService{}`)
- Add error logging for ignored write errors in response handlers

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)