### PR TITLE
Add shared constants package for consistency

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/mattiasgees/spiffe-demo/pkg/common"
 	"github.com/spiffe/go-spiffe/v2/spiffeid"
 	"github.com/spiffe/go-spiffe/v2/spiffetls"
 	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
@@ -84,7 +85,7 @@ func (b *BackendService) run(ctx context.Context) error {
 func (b *BackendService) rootHandler(w http.ResponseWriter, r *http.Request) {
 	log.Printf("Request received from %s", r.RemoteAddr)
 	currentTime := time.Now()
-	formattedTime := currentTime.Format("02/01/06 15:04:05")
+	formattedTime := currentTime.Format(common.TimeFormat)
 	text := fmt.Sprintf("%s: Successfully connected to the backend service!!!", formattedTime)
 	_, _ = io.WriteString(w, text)
 	requestorSPIFFEID, err := spiffetls.PeerIDFromConnectionState(*r.TLS)

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1,0 +1,26 @@
+/*
+Copyright © 2024 Mattias Gees mattias.gees@venafi.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package common
+
+import "time"
+
+const (
+	// TimeFormat used across all services for consistent timestamps
+	TimeFormat = "02/01/06 15:04:05"
+
+	// DefaultTimeout for SPIFFE operations
+	DefaultTimeout = 3 * time.Second
+)

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright © 2024 Mattias Gees mattias.gees@venafi.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package common
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTimeFormatIsValid(t *testing.T) {
+	// Verify the time format string is valid by parsing a formatted time
+	now := time.Now()
+	formatted := now.Format(TimeFormat)
+
+	_, err := time.Parse(TimeFormat, formatted)
+	if err != nil {
+		t.Errorf("TimeFormat is invalid: %v", err)
+	}
+}
+
+func TestTimeFormatProducesExpectedOutput(t *testing.T) {
+	// Test with a known time
+	testTime := time.Date(2024, 3, 15, 14, 30, 45, 0, time.UTC)
+	formatted := testTime.Format(TimeFormat)
+
+	expected := "15/03/24 14:30:45"
+	if formatted != expected {
+		t.Errorf("TimeFormat produced %q, expected %q", formatted, expected)
+	}
+}
+
+func TestDefaultTimeoutIsPositive(t *testing.T) {
+	if DefaultTimeout <= 0 {
+		t.Errorf("DefaultTimeout should be positive, got %v", DefaultTimeout)
+	}
+}
+
+func TestDefaultTimeoutValue(t *testing.T) {
+	expected := 3 * time.Second
+	if DefaultTimeout != expected {
+		t.Errorf("DefaultTimeout is %v, expected %v", DefaultTimeout, expected)
+	}
+}

--- a/pkg/customer/postgresql.go
+++ b/pkg/customer/postgresql.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/stdlib"
+	"github.com/mattiasgees/spiffe-demo/pkg/common"
 	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
 	"github.com/spiffe/go-spiffe/v2/workloadapi"
 )
@@ -111,7 +112,7 @@ func (c *CustomerService) postgreSQLPutHandler(w http.ResponseWriter, r *http.Re
 
 	// Generate the current data and time to insert as extra information into the test_table.
 	currentTime := time.Now()
-	formattedTime := currentTime.Format("02/01/06 15:04:05")
+	formattedTime := currentTime.Format(common.TimeFormat)
 	text := fmt.Sprintf("The time is %s", formattedTime)
 
 	// Execute the PostgreSQL query.

--- a/pkg/httpservice/httpservice.go
+++ b/pkg/httpservice/httpservice.go
@@ -21,6 +21,8 @@ import (
 	"log"
 	"net/http"
 	"time"
+
+	"github.com/mattiasgees/spiffe-demo/pkg/common"
 )
 
 type HTTPService struct {
@@ -57,7 +59,7 @@ func (h *HTTPService) run() error {
 func (h *HTTPService) rootHandler(w http.ResponseWriter, r *http.Request) {
 	log.Printf("Request received from %s", r.RemoteAddr)
 	currentTime := time.Now()
-	formattedTime := currentTime.Format("02/01/06 15:04:05")
+	formattedTime := currentTime.Format(common.TimeFormat)
 	text := fmt.Sprintf("%s: Successfully connected to the HTTP service!!!", formattedTime)
 	_, _ = io.WriteString(w, text)
 }


### PR DESCRIPTION
## Summary
- Create `pkg/common` package with shared constants:
  - `TimeFormat` - consistent timestamp format across all services
  - `DefaultTimeout` - standard timeout for SPIFFE operations
- Update `backend`, `httpservice`, and `postgresql` to use `common.TimeFormat`
- Add tests for the common package (4 tests)

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./pkg/common/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)