### PR TITLE
Add educational comments explaining SPIFFE concepts

### DIFF
--- a/pkg/backend/backend.go
+++ b/pkg/backend/backend.go
@@ -48,6 +48,12 @@ func StartServer(spiffeAuthz, serverAddress string) {
 }
 
 // This gets called from the main function and actually starts an mTLS server that is SPIFFE capable.
+//
+// SPIFFE CONCEPT: SPIFFE-Native Server
+// This backend service demonstrates how to build a server that natively understands SPIFFE.
+// Instead of configuring TLS with certificate files, we use the SPIFFE Workload API to
+// automatically obtain and rotate certificates. The server only accepts connections from
+// clients with specific SPIFFE IDs - implementing identity-based access control.
 func (b *BackendService) run(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -55,21 +61,34 @@ func (b *BackendService) run(ctx context.Context) error {
 	// Set up a `/` resource handler
 	http.HandleFunc("/", b.rootHandler)
 
-	// Create a `workloadapi.X509Source`, it will connect to Workload API using provided socket.
-	// If socket path is not defined using `workloadapi.SourceOption`, value from environment variable `SPIFFE_ENDPOINT_SOCKET` is used.
+	// SPIFFE CONCEPT: Server-Side X509Source
+	// Just like the client, the server uses X509Source to get its identity from SPIRE.
+	// The server's X.509-SVID will be presented to clients during the TLS handshake,
+	// allowing clients to verify they're talking to the right service.
+	// Certificate rotation is automatic - SPIRE handles renewal before expiry.
 	source, err := workloadapi.NewX509Source(ctx)
 	if err != nil {
 		return fmt.Errorf("unable to create X509Source: %w", err)
 	}
 	defer source.Close()
 
-	// Allowed SPIFFE ID
+	// SPIFFE CONCEPT: Client Authorization
+	// The server specifies which SPIFFE ID(s) are allowed to connect.
+	// This is the "authorization" part of authentication + authorization.
+	// Only workloads with this exact SPIFFE ID will be accepted.
+	// You can also use AuthorizeAny() to accept any valid SPIFFE ID,
+	// or implement custom authorization logic with AuthorizeFunc().
 	clientID, err := spiffeid.FromString(b.spiffeAuthz)
 	if err != nil {
 		return fmt.Errorf("invalid SPIFFE ID configuration: %w", err)
 	}
 
-	// Create a `tls.Config` to allow mTLS connections, and verify that presented certificate has SPIFFE ID `spiffe://example.org/client`
+	// SPIFFE CONCEPT: mTLS Server Configuration
+	// MTLSServerConfig creates a TLS configuration for mutual TLS on the server side:
+	//   - First 'source' parameter: provides server certificate to present to clients
+	//   - Second 'source' parameter: provides trust bundles to validate client certificates
+	//   - AuthorizeID(clientID): only accept clients with this exact SPIFFE ID
+	// Note: ListenAndServeTLS("", "") works because the TLS config already has the certs!
 	tlsConfig := tlsconfig.MTLSServerConfig(source, source, tlsconfig.AuthorizeID(clientID))
 	server := &http.Server{
 		Addr:              b.serverAddress,
@@ -78,6 +97,7 @@ func (b *BackendService) run(ctx context.Context) error {
 	}
 
 	// Serve the SPIFFE mTLS server.
+	// Empty strings for cert/key files because TLSConfig already contains our SVID.
 	if err := server.ListenAndServeTLS("", ""); err != nil {
 		return fmt.Errorf("failed to serve: %w", err)
 	}
@@ -93,6 +113,11 @@ func (b *BackendService) rootHandler(w http.ResponseWriter, r *http.Request) {
 	if _, err := io.WriteString(w, text); err != nil {
 		log.Printf("Error writing response: %v", err)
 	}
+
+	// SPIFFE CONCEPT: Identifying the Caller
+	// In a SPIFFE-authenticated connection, we can extract the client's SPIFFE ID
+	// from the TLS connection state. This enables identity-aware logging and
+	// fine-grained authorization decisions within the request handler.
 	requestorSPIFFEID, err := spiffetls.PeerIDFromConnectionState(*r.TLS)
 	if err != nil {
 		log.Printf("Wasn't able to determine the SPIFFE ID of the requestor: %v", err)

--- a/pkg/customer/mtls.go
+++ b/pkg/customer/mtls.go
@@ -36,14 +36,27 @@ func (c *CustomerService) mtlsHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 // General mTLS call to SPIFFE enabled servers. This can be either a SPIFFE native application or a webserver/apiserver that is fronted by a SPIFFE proxy like Envoy.
+//
+// SPIFFE CONCEPT: Application-Layer mTLS
+// This demonstrates how an application can use SPIFFE identities directly in code
+// to establish mutually authenticated TLS connections. The go-spiffe library handles
+// all certificate management automatically - no need to deal with certificate files,
+// rotation, or manual TLS configuration.
 func mTLSCall(w http.ResponseWriter, spiffeAuthZ string, backendAddress string) {
 	w.Header().Set("Content-Type", "text/html")
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
-	// Create a `workloadapi.X509Source`, it will connect to Workload API using provided socket path
-	// If socket path is not defined using `workloadapi.SourceOption`, value from environment variable `SPIFFE_ENDPOINT_SOCKET` is used.
+	// SPIFFE CONCEPT: X509Source and the Workload API
+	// The X509Source automatically connects to the SPIFFE Workload API (typically provided
+	// by SPIRE Agent) via a Unix domain socket. It fetches the workload's X.509-SVID
+	// (SPIFFE Verifiable Identity Document) which contains:
+	//   - The workload's SPIFFE ID in the certificate's URI SAN (e.g., spiffe://example.org/myservice)
+	//   - A private key for proving identity
+	//   - Trust bundles for validating other workloads' certificates
+	// The source automatically handles certificate rotation - when SPIRE rotates the SVID,
+	// the source gets updated transparently.
 	source, err := workloadapi.NewX509Source(ctx)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Unable to create X509Source: %v", err), http.StatusInternalServerError)
@@ -51,14 +64,23 @@ func mTLSCall(w http.ResponseWriter, spiffeAuthZ string, backendAddress string) 
 	}
 	defer source.Close()
 
-	// Allowed SPIFFE ID
+	// SPIFFE CONCEPT: SPIFFE ID Authorization
+	// A SPIFFE ID is a URI that uniquely identifies a workload (e.g., spiffe://trust-domain/path).
+	// Here we parse the expected server's SPIFFE ID that we want to connect to.
+	// This implements zero-trust networking: we don't just accept "any valid certificate",
+	// we verify the exact identity we expect to communicate with.
 	serverID, err := spiffeid.FromString(spiffeAuthZ)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Invalid SPIFFE ID configuration: %v", err), http.StatusInternalServerError)
 		return
 	}
 
-	// Create a `tls.Config` to allow mTLS connections, and verify that presented certificate has SPIFFE ID.
+	// SPIFFE CONCEPT: mTLS Client Configuration
+	// MTLSClientConfig creates a TLS configuration for mutual TLS:
+	//   - First 'source' parameter: provides our client certificate (X.509-SVID) to present to the server
+	//   - Second 'source' parameter: provides trust bundles to validate the server's certificate
+	//   - AuthorizeID(serverID): only accept connections to servers with this exact SPIFFE ID
+	// This ensures both sides prove their identity - true mutual authentication.
 	tlsConfig := tlsconfig.MTLSClientConfig(source, source, tlsconfig.AuthorizeID(serverID))
 	client := &http.Client{
 		Transport: &http.Transport{
@@ -81,7 +103,10 @@ func mTLSCall(w http.ResponseWriter, spiffeAuthZ string, backendAddress string) 
 		return
 	}
 
-	// Retrieve the server SPIFFE ID from the connection.
+	// SPIFFE CONCEPT: Retrieving Peer Identity
+	// After establishing the mTLS connection, we can extract the server's SPIFFE ID
+	// from the TLS connection state. This is useful for logging, auditing, or making
+	// authorization decisions based on the authenticated identity.
 	serverSPIFFEID, err := spiffetls.PeerIDFromConnectionState(*resp.TLS)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("Wasn't able to determine the SPIFFE ID of the server: %v", err), http.StatusInternalServerError)

--- a/pkg/customer/postgresql.go
+++ b/pkg/customer/postgresql.go
@@ -131,19 +131,38 @@ func (c *CustomerService) postgreSQLPutHandler(w http.ResponseWriter, r *http.Re
 
 }
 
+// setupPostgreSQLConnection establishes a SPIFFE-authenticated connection to PostgreSQL.
+//
+// SPIFFE CONCEPT: Database Authentication with X.509 Certificates
+// This demonstrates using SPIFFE identities for database authentication instead of
+// passwords. PostgreSQL supports certificate-based authentication where the client
+// presents an X.509 certificate. By using SPIFFE:
+//   - No passwords to manage, rotate, or accidentally expose
+//   - Identity is cryptographically verifiable
+//   - Automatic certificate rotation via SPIRE
+//   - Database can authorize based on SPIFFE ID (configured in pg_hba.conf)
 func (c *CustomerService) setupPostgreSQLConnection() (*sql.DB, error) {
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 
-	// Create a `workloadapi.X509Source`, it will connect to Workload API using provided socket path.
-	// If socket path is not defined using `workloadapi.SourceOption`, value from environment variable `SPIFFE_ENDPOINT_SOCKET` is used.
+	// SPIFFE CONCEPT: X509Source for Database Connections
+	// We obtain our X.509-SVID from SPIRE, just like for service-to-service mTLS.
+	// The certificate's Common Name (CN) or URI SAN contains our SPIFFE ID,
+	// which PostgreSQL can use for authentication and authorization.
 	source, err := workloadapi.NewX509Source(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create X509Source: %v", err)
 	}
 	defer source.Close()
 
+	// SPIFFE CONCEPT: AuthorizeAny() for Database Connections
+	// Here we use AuthorizeAny() instead of AuthorizeID() because PostgreSQL's
+	// certificate might not have a SPIFFE ID (it's not SPIFFE-native).
+	// The database authenticates us via our certificate; we trust the database
+	// based on network policy or the CA that signed its certificate.
+	// In a full SPIFFE deployment, you could use AuthorizeID() if the database
+	// also has a SPIFFE identity.
 	tlsConfig := tlsconfig.MTLSClientConfig(source, source, tlsconfig.AuthorizeAny())
 
 	connStr := fmt.Sprintf(
@@ -156,7 +175,11 @@ func (c *CustomerService) setupPostgreSQLConnection() (*sql.DB, error) {
 		return nil, fmt.Errorf("unable to parse connection string: %v", err)
 	}
 
-	// Set the TLS config to the SPIFFE TLS config that we retrieved earlier from the Workload API.
+	// SPIFFE CONCEPT: Injecting SPIFFE TLS Config into Database Driver
+	// Most database drivers allow custom TLS configuration. By setting our
+	// SPIFFE-based TLS config, the database connection automatically uses
+	// our X.509-SVID for authentication. No code changes needed in the
+	// actual database queries - authentication is handled at connection time.
 	config.TLSConfig = tlsConfig
 
 	// Open the connection the PostgreSQL database.


### PR DESCRIPTION
## Summary
Add detailed comments to key SPIFFE integration points to help developers understand the concepts being demonstrated.

### Comments added to:
- **`pkg/customer/mtls.go`** - X509Source, Workload API, SPIFFE ID authorization, mTLS client config, peer identity extraction
- **`pkg/backend/backend.go`** - SPIFFE-native server, server-side X509Source, client authorization, mTLS server config, caller identification  
- **`pkg/customer/postgresql.go`** - Database auth with X.509 certificates, AuthorizeAny() usage, injecting SPIFFE TLS into database drivers

### SPIFFE concepts explained:
- What is an X509Source and how it connects to the Workload API
- How SPIFFE IDs are used for authorization (AuthorizeID vs AuthorizeAny)
- Difference between mTLS client and server configuration
- How to extract peer identity from TLS connections
- Using SPIFFE for database authentication without passwords

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)