### PR TITLE
Sanitize branch names for Docker image tags

### DIFF
--- a/.github/workflows/docker-postgresql.yml
+++ b/.github/workflows/docker-postgresql.yml
@@ -42,10 +42,20 @@ jobs:
         env:
           REPOSITORY_NN: '${{ github.repository }}'
 
+      - name: Sanitize branch name for Docker tag
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            # Replace / with - and remove any other invalid characters
+            SANITIZED=$(echo "${{ github.head_ref }}" | sed 's/\//-/g' | sed 's/[^a-zA-Z0-9._-]//g')
+          else
+            SANITIZED="latest"
+          fi
+          echo "DOCKER_TAG=${SANITIZED}" >>${GITHUB_ENV}
+
       - name: Build and push spiffe-postgres
         uses: docker/build-push-action@v6
         with:
             platforms: linux/amd64,linux/arm64
             push: true
             context: ./deploy/postgresql
-            tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/spiffe-postgres:${{ github.event_name == 'pull_request' && github.head_ref || 'latest' }}
+            tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/spiffe-postgres:${{ env.DOCKER_TAG }}

--- a/.github/workflows/docker-spiffe-demo-init.yml
+++ b/.github/workflows/docker-spiffe-demo-init.yml
@@ -40,11 +40,21 @@ jobs:
           echo "REPOSITORY=${REPOSITORY_NN,,}" >>${GITHUB_ENV}
         env:
           REPOSITORY_NN: '${{ github.repository }}'
-          
+
+      - name: Sanitize branch name for Docker tag
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            # Replace / with - and remove any other invalid characters
+            SANITIZED=$(echo "${{ github.head_ref }}" | sed 's/\//-/g' | sed 's/[^a-zA-Z0-9._-]//g')
+          else
+            SANITIZED="latest"
+          fi
+          echo "DOCKER_TAG=${SANITIZED}" >>${GITHUB_ENV}
+
       - name: Build and push spiffe-demo init
         uses: docker/build-push-action@v6
         with:
             platforms: linux/amd64,linux/arm64
             push: true
             context: ./deploy/initcontainer
-            tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/spiffe-demo-init:${{ github.event_name == 'pull_request' && github.head_ref || 'latest' }}
+            tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/spiffe-demo-init:${{ env.DOCKER_TAG }}

--- a/.github/workflows/docker-spiffe-demo.yml
+++ b/.github/workflows/docker-spiffe-demo.yml
@@ -63,10 +63,20 @@ jobs:
         env:
           REPOSITORY_NN: '${{ github.repository }}'
 
+      - name: Sanitize branch name for Docker tag
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            # Replace / with - and remove any other invalid characters
+            SANITIZED=$(echo "${{ github.head_ref }}" | sed 's/\//-/g' | sed 's/[^a-zA-Z0-9._-]//g')
+          else
+            SANITIZED="latest"
+          fi
+          echo "DOCKER_TAG=${SANITIZED}" >>${GITHUB_ENV}
+
       - name: Build and push spiffe-demo
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           push: true
           context: .
-          tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/spiffe-demo:${{ github.event_name == 'pull_request' && github.head_ref || 'latest' }}
+          tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/spiffe-demo:${{ env.DOCKER_TAG }}

--- a/.github/workflows/docker-spiffe-gcp-proxy.yml
+++ b/.github/workflows/docker-spiffe-gcp-proxy.yml
@@ -41,10 +41,20 @@ jobs:
         env:
           REPOSITORY_NN: '${{ github.repository }}'
 
+      - name: Sanitize branch name for Docker tag
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ]; then
+            # Replace / with - and remove any other invalid characters
+            SANITIZED=$(echo "${{ github.head_ref }}" | sed 's/\//-/g' | sed 's/[^a-zA-Z0-9._-]//g')
+          else
+            SANITIZED="latest"
+          fi
+          echo "DOCKER_TAG=${SANITIZED}" >>${GITHUB_ENV}
+
       - name: Build and push spiffe-gcp-proxy
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
           push: true
           context: ./deploy/spiffe-gcp-proxy
-          tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/spiffe-gcp-proxy:${{ github.event_name == 'pull_request' && github.head_ref || 'latest' }}
+          tags: ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/spiffe-gcp-proxy:${{ env.DOCKER_TAG }}


### PR DESCRIPTION
## Summary
- Adds a sanitization step to all Docker build workflows
- Replaces `/` with `-` in branch names (e.g., `feature/foo` → `feature-foo`)
- Removes any other invalid Docker tag characters

This allows any branch naming convention to work with Docker image builds.

## Test plan
- [x] Workflow syntax is valid
- [ ] Test with a branch containing `/` to verify tag sanitization

🤖 Generated with [Claude Code](https://claude.com/claude-code)