### PR TITLE
Add release workflow for binaries and container images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,3 +125,51 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ matrix.image }}:${{ env.VERSION }}
             ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ matrix.image }}:latest
+
+  update-release-notes:
+    name: Update release notes with container images
+    runs-on: ubuntu-latest
+    needs: build-containers
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Set lower case owner name
+        run: |
+          echo "REPOSITORY=${REPOSITORY_NN,,}" >>${GITHUB_ENV}
+        env:
+          REPOSITORY_NN: '${{ github.repository }}'
+
+      - name: Update release notes
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const version = '${{ github.ref_name }}';
+            const repository = process.env.REPOSITORY;
+            const registry = '${{ env.REGISTRY }}';
+
+            const containerImages = `
+
+            ## Container Images
+
+            \`\`\`
+            docker pull ${registry}/${repository}/spiffe-demo:${version}
+            docker pull ${registry}/${repository}/spiffe-demo-init:${version}
+            docker pull ${registry}/${repository}/spiffe-postgres:${version}
+            docker pull ${registry}/${repository}/spiffe-gcp-proxy:${version}
+            \`\`\`
+            `;
+
+            const { data: release } = await github.rest.repos.getReleaseByTag({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag: version
+            });
+
+            await github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: release.id,
+              body: release.body + containerImages
+            });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,127 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-binaries:
+    name: Build Go binaries
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Build binary
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          go build -o spiffe-demo-${{ matrix.goos }}-${{ matrix.goarch }} .
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: spiffe-demo-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: spiffe-demo-${{ matrix.goos }}-${{ matrix.goarch }}
+
+  upload-binaries:
+    name: Upload binaries to release
+    runs-on: ubuntu-latest
+    needs: build-binaries
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: binaries
+          pattern: spiffe-demo-*
+          merge-multiple: true
+
+      - name: Upload binaries to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: binaries/*
+
+  build-containers:
+    name: Build container images
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    strategy:
+      matrix:
+        include:
+          - image: spiffe-demo
+            context: .
+          - image: spiffe-demo-init
+            context: ./deploy/initcontainer
+          - image: spiffe-postgres
+            context: ./deploy/postgresql
+          - image: spiffe-gcp-proxy
+            context: ./deploy/spiffe-gcp-proxy
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set lower case owner name
+        run: |
+          echo "REPOSITORY=${REPOSITORY_NN,,}" >>${GITHUB_ENV}
+        env:
+          REPOSITORY_NN: '${{ github.repository }}'
+
+      - name: Extract version from tag
+        run: |
+          echo "VERSION=${GITHUB_REF_NAME}" >>${GITHUB_ENV}
+
+      - name: Build and push ${{ matrix.image }}
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true
+          context: ${{ matrix.context }}
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ matrix.image }}:${{ env.VERSION }}
+            ${{ env.REGISTRY }}/${{ env.REPOSITORY }}/${{ matrix.image }}:latest


### PR DESCRIPTION
## Summary

Adds a new GitHub Actions workflow that triggers when a release is published.

### What it does

**1. Builds Go binaries for multiple platforms:**
| OS | Architecture | Binary name |
|----|--------------|-------------|
| Linux | x86_64 | `spiffe-demo-linux-amd64` |
| Linux | ARM64 | `spiffe-demo-linux-arm64` |
| macOS | x86_64 | `spiffe-demo-darwin-amd64` |
| macOS | ARM64 | `spiffe-demo-darwin-arm64` |

**2. Attaches binaries to the GitHub release** as downloadable assets

**3. Builds and pushes container images:**
- `spiffe-demo`
- `spiffe-demo-init`
- `spiffe-postgres`
- `spiffe-gcp-proxy`

**4. Tags images with:**
- Release version (e.g., `v2.0.0`)
- `latest`

### Example output for release `v2.0.0`

**Release assets:**
```
spiffe-demo-linux-amd64
spiffe-demo-linux-arm64
spiffe-demo-darwin-amd64
spiffe-demo-darwin-arm64
```

**Container images:**
```
ghcr.io/mattiasgees/spiffe-demo/spiffe-demo:v2.0.0
ghcr.io/mattiasgees/spiffe-demo/spiffe-demo:latest
(and same for other 3 images)
```

## Test plan
- [x] Workflow syntax is valid
- [ ] Create a test release to verify workflow runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)