### PR TITLE
Add ledger service data models and database layer

### DIFF
--- a/deploy/postgresql/init-trustbank.sql
+++ b/deploy/postgresql/init-trustbank.sql
@@ -1,0 +1,42 @@
+-- TrustBank database schema
+-- This script initializes the database with the required tables and seed data.
+
+-- Create the trustbank database if it doesn't exist
+-- Note: This is handled separately in the init script
+
+-- Accounts table
+CREATE TABLE IF NOT EXISTS accounts (
+    id UUID PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    balance DECIMAL(15,2) NOT NULL DEFAULT 0.00,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    CONSTRAINT balance_non_negative CHECK (balance >= 0)
+);
+
+-- Transactions table
+CREATE TABLE IF NOT EXISTS transactions (
+    id UUID PRIMARY KEY,
+    from_account UUID NOT NULL REFERENCES accounts(id),
+    to_account UUID NOT NULL REFERENCES accounts(id),
+    amount DECIMAL(15,2) NOT NULL,
+    description VARCHAR(255),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    CONSTRAINT amount_positive CHECK (amount > 0),
+    CONSTRAINT different_accounts CHECK (from_account != to_account)
+);
+
+-- Indexes for better query performance
+CREATE INDEX IF NOT EXISTS idx_transactions_from_account ON transactions(from_account);
+CREATE INDEX IF NOT EXISTS idx_transactions_to_account ON transactions(to_account);
+CREATE INDEX IF NOT EXISTS idx_transactions_created_at ON transactions(created_at DESC);
+
+-- Seed data: Create demo accounts
+INSERT INTO accounts (id, name, balance, created_at) VALUES
+    ('11111111-1111-1111-1111-111111111111', 'Checking', 5000.00, NOW()),
+    ('22222222-2222-2222-2222-222222222222', 'Savings', 5000.00, NOW())
+ON CONFLICT (id) DO NOTHING;
+
+-- Grant permissions to the ledger service user
+-- Note: The user is created in the main PostgreSQL init script
+GRANT SELECT, INSERT, UPDATE ON accounts TO "spiffe-demo-ledger";
+GRANT SELECT, INSERT ON transactions TO "spiffe-demo-ledger";

--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
+	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -139,6 +139,8 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDcg+AAIFXc=
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=
+github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
+github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 h1:+jumHNA0Wrelhe64i8F6HNlS8pkoyMv5sreGx2Ry5Rw=
 github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8/go.mod h1:3n1Cwaq1E1/1lhQhtRK2ts/ZwZEhjcQeJQ1RuC6Q/8U=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=

--- a/pkg/ledger/errors.go
+++ b/pkg/ledger/errors.go
@@ -1,0 +1,42 @@
+/*
+Copyright © 2024 Mattias Gees mattias.gees@venafi.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ledger
+
+import "errors"
+
+var (
+	// ErrAccountNotFound is returned when an account is not found.
+	ErrAccountNotFound = errors.New("account not found")
+
+	// ErrInsufficientFunds is returned when an account has insufficient funds for a transfer.
+	ErrInsufficientFunds = errors.New("insufficient funds")
+
+	// ErrInvalidFromAccount is returned when the from account is invalid.
+	ErrInvalidFromAccount = errors.New("invalid from account")
+
+	// ErrInvalidToAccount is returned when the to account is invalid.
+	ErrInvalidToAccount = errors.New("invalid to account")
+
+	// ErrSameAccount is returned when trying to transfer to the same account.
+	ErrSameAccount = errors.New("cannot transfer to the same account")
+
+	// ErrInvalidAmount is returned when the transfer amount is invalid.
+	ErrInvalidAmount = errors.New("amount must be greater than zero")
+
+	// ErrTransactionNotFound is returned when a transaction is not found.
+	ErrTransactionNotFound = errors.New("transaction not found")
+)

--- a/pkg/ledger/mock_store.go
+++ b/pkg/ledger/mock_store.go
@@ -1,0 +1,175 @@
+/*
+Copyright © 2024 Mattias Gees mattias.gees@venafi.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ledger
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+// MockStore is an in-memory implementation of the Store interface for testing.
+type MockStore struct {
+	mu           sync.RWMutex
+	accounts     map[uuid.UUID]*Account
+	transactions []Transaction
+}
+
+// NewMockStore creates a new MockStore with default test accounts.
+func NewMockStore() *MockStore {
+	store := &MockStore{
+		accounts:     make(map[uuid.UUID]*Account),
+		transactions: make([]Transaction, 0),
+	}
+
+	// Add default test accounts
+	checkingID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	savingsID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+
+	store.accounts[checkingID] = &Account{
+		ID:        checkingID,
+		Name:      "Checking",
+		Balance:   decimal.NewFromFloat(5000.00),
+		CreatedAt: time.Now().UTC(),
+	}
+
+	store.accounts[savingsID] = &Account{
+		ID:        savingsID,
+		Name:      "Savings",
+		Balance:   decimal.NewFromFloat(5000.00),
+		CreatedAt: time.Now().UTC(),
+	}
+
+	return store
+}
+
+// GetAccounts returns all accounts.
+func (s *MockStore) GetAccounts(ctx context.Context) ([]Account, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	accounts := make([]Account, 0, len(s.accounts))
+	for _, a := range s.accounts {
+		accounts = append(accounts, *a)
+	}
+	return accounts, nil
+}
+
+// GetAccount returns a single account by ID.
+func (s *MockStore) GetAccount(ctx context.Context, id uuid.UUID) (*Account, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	account, ok := s.accounts[id]
+	if !ok {
+		return nil, ErrAccountNotFound
+	}
+	// Return a copy to prevent external modification
+	accountCopy := *account
+	return &accountCopy, nil
+}
+
+// GetTransactions returns all transactions, ordered by creation time (newest first).
+func (s *MockStore) GetTransactions(ctx context.Context) ([]Transaction, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// Return a copy of the transactions slice
+	transactions := make([]Transaction, len(s.transactions))
+	copy(transactions, s.transactions)
+	return transactions, nil
+}
+
+// GetTransaction returns a single transaction by ID.
+func (s *MockStore) GetTransaction(ctx context.Context, id uuid.UUID) (*Transaction, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for _, t := range s.transactions {
+		if t.ID == id {
+			return &t, nil
+		}
+	}
+	return nil, ErrTransactionNotFound
+}
+
+// CreateTransfer creates a new transfer between accounts.
+func (s *MockStore) CreateTransfer(ctx context.Context, req TransferRequest) (*Transaction, error) {
+	// Validate the request
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Check from account exists and has sufficient funds
+	fromAccount, ok := s.accounts[req.FromAccount]
+	if !ok {
+		return nil, ErrAccountNotFound
+	}
+
+	if fromAccount.Balance.LessThan(req.Amount) {
+		return nil, ErrInsufficientFunds
+	}
+
+	// Check to account exists
+	toAccount, ok := s.accounts[req.ToAccount]
+	if !ok {
+		return nil, ErrAccountNotFound
+	}
+
+	// Perform the transfer
+	fromAccount.Balance = fromAccount.Balance.Sub(req.Amount)
+	toAccount.Balance = toAccount.Balance.Add(req.Amount)
+
+	// Create transaction record
+	transaction := Transaction{
+		ID:          uuid.New(),
+		FromAccount: req.FromAccount,
+		ToAccount:   req.ToAccount,
+		Amount:      req.Amount,
+		Description: req.Description,
+		CreatedAt:   time.Now().UTC(),
+	}
+
+	// Prepend to transactions list (newest first)
+	s.transactions = append([]Transaction{transaction}, s.transactions...)
+
+	return &transaction, nil
+}
+
+// Close closes the store (no-op for mock).
+func (s *MockStore) Close() error {
+	return nil
+}
+
+// Reset resets the mock store to its initial state (useful for tests).
+func (s *MockStore) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	checkingID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	savingsID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+
+	s.accounts[checkingID].Balance = decimal.NewFromFloat(5000.00)
+	s.accounts[savingsID].Balance = decimal.NewFromFloat(5000.00)
+	s.transactions = make([]Transaction, 0)
+}

--- a/pkg/ledger/models.go
+++ b/pkg/ledger/models.go
@@ -1,0 +1,89 @@
+/*
+Copyright © 2024 Mattias Gees mattias.gees@venafi.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package ledger provides the TrustBank ledger service for managing accounts and transactions.
+package ledger
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+// Account represents a bank account in the TrustBank system.
+type Account struct {
+	ID        uuid.UUID       `json:"id"`
+	Name      string          `json:"name"`
+	Balance   decimal.Decimal `json:"balance"`
+	CreatedAt time.Time       `json:"created_at"`
+}
+
+// Transaction represents a money transfer between accounts.
+type Transaction struct {
+	ID          uuid.UUID       `json:"id"`
+	FromAccount uuid.UUID       `json:"from_account"`
+	ToAccount   uuid.UUID       `json:"to_account"`
+	Amount      decimal.Decimal `json:"amount"`
+	Description string          `json:"description,omitempty"`
+	CreatedAt   time.Time       `json:"created_at"`
+}
+
+// TransferRequest represents a request to transfer money between accounts.
+type TransferRequest struct {
+	FromAccount uuid.UUID       `json:"from_account"`
+	ToAccount   uuid.UUID       `json:"to_account"`
+	Amount      decimal.Decimal `json:"amount"`
+	Description string          `json:"description,omitempty"`
+}
+
+// Validate checks if the transfer request is valid.
+func (t *TransferRequest) Validate() error {
+	if t.FromAccount == uuid.Nil {
+		return ErrInvalidFromAccount
+	}
+	if t.ToAccount == uuid.Nil {
+		return ErrInvalidToAccount
+	}
+	if t.FromAccount == t.ToAccount {
+		return ErrSameAccount
+	}
+	if t.Amount.LessThanOrEqual(decimal.Zero) {
+		return ErrInvalidAmount
+	}
+	return nil
+}
+
+// AccountsResponse represents the response for listing accounts.
+type AccountsResponse struct {
+	Accounts []Account `json:"accounts"`
+}
+
+// TransactionsResponse represents the response for listing transactions.
+type TransactionsResponse struct {
+	Transactions []Transaction `json:"transactions"`
+}
+
+// TransactionResponse represents the response for a single transaction.
+type TransactionResponse struct {
+	Transaction Transaction `json:"transaction"`
+}
+
+// ErrorResponse represents an error response from the API.
+type ErrorResponse struct {
+	Error   string `json:"error"`
+	Message string `json:"message,omitempty"`
+}

--- a/pkg/ledger/models_test.go
+++ b/pkg/ledger/models_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright © 2024 Mattias Gees mattias.gees@venafi.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ledger
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+func TestTransferRequest_Validate(t *testing.T) {
+	validFromAccount := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	validToAccount := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	validAmount := decimal.NewFromFloat(100.00)
+
+	tests := []struct {
+		name    string
+		request TransferRequest
+		wantErr error
+	}{
+		{
+			name: "valid request",
+			request: TransferRequest{
+				FromAccount: validFromAccount,
+				ToAccount:   validToAccount,
+				Amount:      validAmount,
+				Description: "Test transfer",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "valid request without description",
+			request: TransferRequest{
+				FromAccount: validFromAccount,
+				ToAccount:   validToAccount,
+				Amount:      validAmount,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "nil from account",
+			request: TransferRequest{
+				FromAccount: uuid.Nil,
+				ToAccount:   validToAccount,
+				Amount:      validAmount,
+			},
+			wantErr: ErrInvalidFromAccount,
+		},
+		{
+			name: "nil to account",
+			request: TransferRequest{
+				FromAccount: validFromAccount,
+				ToAccount:   uuid.Nil,
+				Amount:      validAmount,
+			},
+			wantErr: ErrInvalidToAccount,
+		},
+		{
+			name: "same account",
+			request: TransferRequest{
+				FromAccount: validFromAccount,
+				ToAccount:   validFromAccount,
+				Amount:      validAmount,
+			},
+			wantErr: ErrSameAccount,
+		},
+		{
+			name: "zero amount",
+			request: TransferRequest{
+				FromAccount: validFromAccount,
+				ToAccount:   validToAccount,
+				Amount:      decimal.Zero,
+			},
+			wantErr: ErrInvalidAmount,
+		},
+		{
+			name: "negative amount",
+			request: TransferRequest{
+				FromAccount: validFromAccount,
+				ToAccount:   validToAccount,
+				Amount:      decimal.NewFromFloat(-100.00),
+			},
+			wantErr: ErrInvalidAmount,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.request.Validate()
+			if err != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestAccount_JSONTags(t *testing.T) {
+	// This test ensures the JSON tags are correctly set by marshaling/unmarshaling
+	// For now, just verify the struct can be created
+	account := Account{
+		ID:      uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+		Name:    "Test Account",
+		Balance: decimal.NewFromFloat(1000.00),
+	}
+
+	if account.Name != "Test Account" {
+		t.Errorf("Expected name 'Test Account', got '%s'", account.Name)
+	}
+
+	if !account.Balance.Equal(decimal.NewFromFloat(1000.00)) {
+		t.Errorf("Expected balance 1000.00, got %s", account.Balance.String())
+	}
+}
+
+func TestTransaction_JSONTags(t *testing.T) {
+	// Verify the struct can be created
+	transaction := Transaction{
+		ID:          uuid.MustParse("33333333-3333-3333-3333-333333333333"),
+		FromAccount: uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+		ToAccount:   uuid.MustParse("22222222-2222-2222-2222-222222222222"),
+		Amount:      decimal.NewFromFloat(100.00),
+		Description: "Test transaction",
+	}
+
+	if !transaction.Amount.Equal(decimal.NewFromFloat(100.00)) {
+		t.Errorf("Expected amount 100.00, got %s", transaction.Amount.String())
+	}
+
+	if transaction.Description != "Test transaction" {
+		t.Errorf("Expected description 'Test transaction', got '%s'", transaction.Description)
+	}
+}

--- a/pkg/ledger/postgres.go
+++ b/pkg/ledger/postgres.go
@@ -40,7 +40,6 @@ type PostgresStore struct {
 type PostgresConfig struct {
 	Host     string
 	Port     int
-	User     string
 	Database string
 }
 
@@ -51,10 +50,22 @@ type PostgresConfig struct {
 // Instead of using static certificates or passwords, the ledger service uses its
 // SPIFFE identity (X.509-SVID) to authenticate to PostgreSQL. The X509Source
 // automatically obtains and rotates certificates from the SPIFFE Workload API.
-// PostgreSQL is configured to trust the SPIFFE CA and map the SPIFFE ID's CN
-// (Common Name) to a database user.
+// PostgreSQL is configured to trust the SPIFFE CA and map the certificate's
+// Common Name (CN) to a database user - no separate username configuration needed.
 func NewPostgresStore(ctx context.Context, cfg PostgresConfig, source *workloadapi.X509Source) (*PostgresStore, error) {
-	connString := buildConnectionString(cfg)
+	// Extract username from the SVID's Common Name
+	svid, err := source.GetX509SVID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get X509-SVID: %w", err)
+	}
+
+	// The CN from the SPIFFE certificate is used as the PostgreSQL username
+	user := svid.Certificates[0].Subject.CommonName
+	if user == "" {
+		return nil, fmt.Errorf("SVID certificate has no Common Name for database user")
+	}
+
+	connString := buildConnectionString(cfg, user)
 
 	poolConfig, err := pgxpool.ParseConfig(connString)
 	if err != nil {
@@ -89,7 +100,8 @@ func NewPostgresStore(ctx context.Context, cfg PostgresConfig, source *workloada
 }
 
 // buildConnectionString builds a PostgreSQL connection string from the config.
-func buildConnectionString(cfg PostgresConfig) string {
+// The user parameter is extracted from the SPIFFE SVID's Common Name.
+func buildConnectionString(cfg PostgresConfig, user string) string {
 	port := cfg.Port
 	if port == 0 {
 		port = 5432
@@ -103,7 +115,7 @@ func buildConnectionString(cfg PostgresConfig) string {
 	// Always use 'require' SSL mode since we're using SPIFFE mTLS
 	return fmt.Sprintf(
 		"host=%s port=%d user=%s dbname=%s sslmode=require",
-		cfg.Host, port, cfg.User, database,
+		cfg.Host, port, user, database,
 	)
 }
 

--- a/pkg/ledger/postgres.go
+++ b/pkg/ledger/postgres.go
@@ -1,0 +1,369 @@
+/*
+Copyright © 2024 Mattias Gees mattias.gees@venafi.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ledger
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+)
+
+// PostgresStore implements the Store interface using PostgreSQL.
+type PostgresStore struct {
+	pool *pgxpool.Pool
+}
+
+// PostgresConfig contains the configuration for connecting to PostgreSQL.
+type PostgresConfig struct {
+	Host     string
+	Port     int
+	User     string
+	Database string
+	// SSLMode specifies the SSL mode (disable, require, verify-ca, verify-full)
+	SSLMode string
+	// SSLCert is the path to the client certificate file (for X.509 auth)
+	SSLCert string
+	// SSLKey is the path to the client private key file (for X.509 auth)
+	SSLKey string
+	// SSLRootCert is the path to the root CA certificate file
+	SSLRootCert string
+}
+
+// NewPostgresStore creates a new PostgresStore with the given configuration.
+func NewPostgresStore(ctx context.Context, cfg PostgresConfig) (*PostgresStore, error) {
+	connString := buildConnectionString(cfg)
+
+	poolConfig, err := pgxpool.ParseConfig(connString)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse connection string: %w", err)
+	}
+
+	// Configure TLS if SSL certificates are provided
+	if cfg.SSLCert != "" && cfg.SSLKey != "" {
+		tlsConfig, err := buildTLSConfig(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build TLS config: %w", err)
+		}
+		poolConfig.ConnConfig.TLSConfig = tlsConfig
+	}
+
+	// Set pool configuration
+	poolConfig.MaxConns = 10
+	poolConfig.MinConns = 2
+	poolConfig.MaxConnLifetime = time.Hour
+	poolConfig.MaxConnIdleTime = 30 * time.Minute
+
+	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create connection pool: %w", err)
+	}
+
+	// Test the connection
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		return nil, fmt.Errorf("failed to ping database: %w", err)
+	}
+
+	return &PostgresStore{pool: pool}, nil
+}
+
+// buildConnectionString builds a PostgreSQL connection string from the config.
+func buildConnectionString(cfg PostgresConfig) string {
+	port := cfg.Port
+	if port == 0 {
+		port = 5432
+	}
+
+	database := cfg.Database
+	if database == "" {
+		database = "trustbank"
+	}
+
+	sslMode := cfg.SSLMode
+	if sslMode == "" {
+		sslMode = "disable"
+	}
+
+	return fmt.Sprintf(
+		"host=%s port=%d user=%s dbname=%s sslmode=%s",
+		cfg.Host, port, cfg.User, database, sslMode,
+	)
+}
+
+// buildTLSConfig builds a TLS configuration for X.509 certificate authentication.
+func buildTLSConfig(cfg PostgresConfig) (*tls.Config, error) {
+	cert, err := tls.LoadX509KeyPair(cfg.SSLCert, cfg.SSLKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load client certificate: %w", err)
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	if cfg.SSLRootCert != "" {
+		rootCert, err := os.ReadFile(cfg.SSLRootCert)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read root certificate: %w", err)
+		}
+
+		rootCertPool := x509.NewCertPool()
+		if !rootCertPool.AppendCertsFromPEM(rootCert) {
+			return nil, fmt.Errorf("failed to append root certificate")
+		}
+		tlsConfig.RootCAs = rootCertPool
+	}
+
+	return tlsConfig, nil
+}
+
+// Close closes the database connection pool.
+func (s *PostgresStore) Close() error {
+	s.pool.Close()
+	return nil
+}
+
+// GetAccounts returns all accounts.
+func (s *PostgresStore) GetAccounts(ctx context.Context) ([]Account, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, name, balance, created_at
+		FROM accounts
+		ORDER BY name
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query accounts: %w", err)
+	}
+	defer rows.Close()
+
+	var accounts []Account
+	for rows.Next() {
+		var a Account
+		var balanceStr string
+		if err := rows.Scan(&a.ID, &a.Name, &balanceStr, &a.CreatedAt); err != nil {
+			return nil, fmt.Errorf("failed to scan account: %w", err)
+		}
+		a.Balance, err = decimal.NewFromString(balanceStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse balance: %w", err)
+		}
+		accounts = append(accounts, a)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating accounts: %w", err)
+	}
+
+	return accounts, nil
+}
+
+// GetAccount returns a single account by ID.
+func (s *PostgresStore) GetAccount(ctx context.Context, id uuid.UUID) (*Account, error) {
+	var a Account
+	var balanceStr string
+
+	err := s.pool.QueryRow(ctx, `
+		SELECT id, name, balance, created_at
+		FROM accounts
+		WHERE id = $1
+	`, id).Scan(&a.ID, &a.Name, &balanceStr, &a.CreatedAt)
+
+	if err == pgx.ErrNoRows {
+		return nil, ErrAccountNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to query account: %w", err)
+	}
+
+	a.Balance, err = decimal.NewFromString(balanceStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse balance: %w", err)
+	}
+
+	return &a, nil
+}
+
+// GetTransactions returns all transactions, ordered by creation time (newest first).
+func (s *PostgresStore) GetTransactions(ctx context.Context) ([]Transaction, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, from_account, to_account, amount, description, created_at
+		FROM transactions
+		ORDER BY created_at DESC
+		LIMIT 100
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query transactions: %w", err)
+	}
+	defer rows.Close()
+
+	var transactions []Transaction
+	for rows.Next() {
+		var t Transaction
+		var amountStr string
+		var description *string
+		if err := rows.Scan(&t.ID, &t.FromAccount, &t.ToAccount, &amountStr, &description, &t.CreatedAt); err != nil {
+			return nil, fmt.Errorf("failed to scan transaction: %w", err)
+		}
+		t.Amount, err = decimal.NewFromString(amountStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse amount: %w", err)
+		}
+		if description != nil {
+			t.Description = *description
+		}
+		transactions = append(transactions, t)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating transactions: %w", err)
+	}
+
+	return transactions, nil
+}
+
+// GetTransaction returns a single transaction by ID.
+func (s *PostgresStore) GetTransaction(ctx context.Context, id uuid.UUID) (*Transaction, error) {
+	var t Transaction
+	var amountStr string
+	var description *string
+
+	err := s.pool.QueryRow(ctx, `
+		SELECT id, from_account, to_account, amount, description, created_at
+		FROM transactions
+		WHERE id = $1
+	`, id).Scan(&t.ID, &t.FromAccount, &t.ToAccount, &amountStr, &description, &t.CreatedAt)
+
+	if err == pgx.ErrNoRows {
+		return nil, ErrTransactionNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to query transaction: %w", err)
+	}
+
+	t.Amount, err = decimal.NewFromString(amountStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse amount: %w", err)
+	}
+	if description != nil {
+		t.Description = *description
+	}
+
+	return &t, nil
+}
+
+// CreateTransfer creates a new transfer between accounts.
+// This operation is atomic - either both accounts are updated or neither is.
+func (s *PostgresStore) CreateTransfer(ctx context.Context, req TransferRequest) (*Transaction, error) {
+	// Validate the request
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Start a transaction
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	// Lock and check the from account
+	var fromBalance string
+	err = tx.QueryRow(ctx, `
+		SELECT balance FROM accounts WHERE id = $1 FOR UPDATE
+	`, req.FromAccount).Scan(&fromBalance)
+	if err == pgx.ErrNoRows {
+		return nil, ErrAccountNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to lock from account: %w", err)
+	}
+
+	fromBalanceDec, err := decimal.NewFromString(fromBalance)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse from balance: %w", err)
+	}
+
+	if fromBalanceDec.LessThan(req.Amount) {
+		return nil, ErrInsufficientFunds
+	}
+
+	// Lock and check the to account exists
+	var toBalance string
+	err = tx.QueryRow(ctx, `
+		SELECT balance FROM accounts WHERE id = $1 FOR UPDATE
+	`, req.ToAccount).Scan(&toBalance)
+	if err == pgx.ErrNoRows {
+		return nil, ErrAccountNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to lock to account: %w", err)
+	}
+
+	// Deduct from the from account
+	_, err = tx.Exec(ctx, `
+		UPDATE accounts SET balance = balance - $1 WHERE id = $2
+	`, req.Amount.String(), req.FromAccount)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deduct from account: %w", err)
+	}
+
+	// Add to the to account
+	_, err = tx.Exec(ctx, `
+		UPDATE accounts SET balance = balance + $1 WHERE id = $2
+	`, req.Amount.String(), req.ToAccount)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add to account: %w", err)
+	}
+
+	// Create the transaction record
+	transaction := Transaction{
+		ID:          uuid.New(),
+		FromAccount: req.FromAccount,
+		ToAccount:   req.ToAccount,
+		Amount:      req.Amount,
+		Description: req.Description,
+		CreatedAt:   time.Now().UTC(),
+	}
+
+	var descPtr *string
+	if req.Description != "" {
+		descPtr = &req.Description
+	}
+
+	_, err = tx.Exec(ctx, `
+		INSERT INTO transactions (id, from_account, to_account, amount, description, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6)
+	`, transaction.ID, transaction.FromAccount, transaction.ToAccount, transaction.Amount.String(), descPtr, transaction.CreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to insert transaction: %w", err)
+	}
+
+	// Commit the transaction
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return &transaction, nil
+}

--- a/pkg/ledger/postgres.go
+++ b/pkg/ledger/postgres.go
@@ -21,13 +21,14 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/shopspring/decimal"
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
 )
 
 // PostgresStore implements the Store interface using PostgreSQL.
@@ -41,18 +42,18 @@ type PostgresConfig struct {
 	Port     int
 	User     string
 	Database string
-	// SSLMode specifies the SSL mode (disable, require, verify-ca, verify-full)
-	SSLMode string
-	// SSLCert is the path to the client certificate file (for X.509 auth)
-	SSLCert string
-	// SSLKey is the path to the client private key file (for X.509 auth)
-	SSLKey string
-	// SSLRootCert is the path to the root CA certificate file
-	SSLRootCert string
 }
 
 // NewPostgresStore creates a new PostgresStore with the given configuration.
-func NewPostgresStore(ctx context.Context, cfg PostgresConfig) (*PostgresStore, error) {
+// It requires a SPIFFE X509Source for mTLS authentication to PostgreSQL.
+//
+// SPIFFE CONCEPT: Database Authentication with X.509-SVIDs
+// Instead of using static certificates or passwords, the ledger service uses its
+// SPIFFE identity (X.509-SVID) to authenticate to PostgreSQL. The X509Source
+// automatically obtains and rotates certificates from the SPIFFE Workload API.
+// PostgreSQL is configured to trust the SPIFFE CA and map the SPIFFE ID's CN
+// (Common Name) to a database user.
+func NewPostgresStore(ctx context.Context, cfg PostgresConfig, source *workloadapi.X509Source) (*PostgresStore, error) {
 	connString := buildConnectionString(cfg)
 
 	poolConfig, err := pgxpool.ParseConfig(connString)
@@ -60,14 +61,12 @@ func NewPostgresStore(ctx context.Context, cfg PostgresConfig) (*PostgresStore, 
 		return nil, fmt.Errorf("failed to parse connection string: %w", err)
 	}
 
-	// Configure TLS if SSL certificates are provided
-	if cfg.SSLCert != "" && cfg.SSLKey != "" {
-		tlsConfig, err := buildTLSConfig(cfg)
-		if err != nil {
-			return nil, fmt.Errorf("failed to build TLS config: %w", err)
-		}
-		poolConfig.ConnConfig.TLSConfig = tlsConfig
+	// Configure TLS using SPIFFE X509Source
+	tlsConfig, err := buildSPIFFETLSConfig(source)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build SPIFFE TLS config: %w", err)
 	}
+	poolConfig.ConnConfig.TLSConfig = tlsConfig
 
 	// Set pool configuration
 	poolConfig.MaxConns = 10
@@ -101,43 +100,67 @@ func buildConnectionString(cfg PostgresConfig) string {
 		database = "trustbank"
 	}
 
-	sslMode := cfg.SSLMode
-	if sslMode == "" {
-		sslMode = "disable"
-	}
-
+	// Always use 'require' SSL mode since we're using SPIFFE mTLS
 	return fmt.Sprintf(
-		"host=%s port=%d user=%s dbname=%s sslmode=%s",
-		cfg.Host, port, cfg.User, database, sslMode,
+		"host=%s port=%d user=%s dbname=%s sslmode=require",
+		cfg.Host, port, cfg.User, database,
 	)
 }
 
-// buildTLSConfig builds a TLS configuration for X.509 certificate authentication.
-func buildTLSConfig(cfg PostgresConfig) (*tls.Config, error) {
-	cert, err := tls.LoadX509KeyPair(cfg.SSLCert, cfg.SSLKey)
+// buildSPIFFETLSConfig builds a TLS configuration using SPIFFE X509Source.
+//
+// SPIFFE CONCEPT: Dynamic Certificate Configuration
+// The TLS config uses GetClientCertificate callback which is called on each
+// new connection. This ensures that if SPIRE rotates the certificate, the new
+// certificate is automatically used for subsequent connections without any
+// application restart or manual intervention.
+func buildSPIFFETLSConfig(source *workloadapi.X509Source) (*tls.Config, error) {
+	svid, err := source.GetX509SVID()
 	if err != nil {
-		return nil, fmt.Errorf("failed to load client certificate: %w", err)
+		return nil, fmt.Errorf("failed to get X509-SVID: %w", err)
+	}
+
+	bundle, err := source.GetX509BundleForTrustDomain(svid.ID.TrustDomain())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get X509 bundle: %w", err)
+	}
+
+	// Convert the X.509 bundle authorities to a cert pool
+	rootCAs, err := x509CertPoolFromBundle(bundle)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cert pool: %w", err)
 	}
 
 	tlsConfig := &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		MinVersion:   tls.VersionTLS12,
-	}
-
-	if cfg.SSLRootCert != "" {
-		rootCert, err := os.ReadFile(cfg.SSLRootCert)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read root certificate: %w", err)
-		}
-
-		rootCertPool := x509.NewCertPool()
-		if !rootCertPool.AppendCertsFromPEM(rootCert) {
-			return nil, fmt.Errorf("failed to append root certificate")
-		}
-		tlsConfig.RootCAs = rootCertPool
+		// GetClientCertificate is called on each connection, ensuring fresh certs
+		GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			svid, err := source.GetX509SVID()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get X509-SVID: %w", err)
+			}
+			tlsCert := &tls.Certificate{
+				Certificate: make([][]byte, len(svid.Certificates)),
+				PrivateKey:  svid.PrivateKey,
+			}
+			for i, cert := range svid.Certificates {
+				tlsCert.Certificate[i] = cert.Raw
+			}
+			return tlsCert, nil
+		},
+		RootCAs:    rootCAs,
+		MinVersion: tls.VersionTLS12,
 	}
 
 	return tlsConfig, nil
+}
+
+// x509CertPoolFromBundle creates an x509.CertPool from a SPIFFE X509Bundle.
+func x509CertPoolFromBundle(bundle *x509bundle.Bundle) (*x509.CertPool, error) {
+	pool := x509.NewCertPool()
+	for _, cert := range bundle.X509Authorities() {
+		pool.AddCert(cert)
+	}
+	return pool, nil
 }
 
 // Close closes the database connection pool.

--- a/pkg/ledger/store.go
+++ b/pkg/ledger/store.go
@@ -1,0 +1,46 @@
+/*
+Copyright © 2024 Mattias Gees mattias.gees@venafi.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ledger
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// Store defines the interface for ledger data persistence.
+// This interface allows for easy mocking in tests.
+type Store interface {
+	// GetAccounts returns all accounts.
+	GetAccounts(ctx context.Context) ([]Account, error)
+
+	// GetAccount returns a single account by ID.
+	GetAccount(ctx context.Context, id uuid.UUID) (*Account, error)
+
+	// GetTransactions returns all transactions, ordered by creation time (newest first).
+	GetTransactions(ctx context.Context) ([]Transaction, error)
+
+	// GetTransaction returns a single transaction by ID.
+	GetTransaction(ctx context.Context, id uuid.UUID) (*Transaction, error)
+
+	// CreateTransfer creates a new transfer between accounts.
+	// This operation is atomic - either both accounts are updated or neither is.
+	CreateTransfer(ctx context.Context, req TransferRequest) (*Transaction, error)
+
+	// Close closes the store connection.
+	Close() error
+}

--- a/pkg/ledger/store_test.go
+++ b/pkg/ledger/store_test.go
@@ -1,0 +1,303 @@
+/*
+Copyright © 2024 Mattias Gees mattias.gees@venafi.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ledger
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+var (
+	checkingID = uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	savingsID  = uuid.MustParse("22222222-2222-2222-2222-222222222222")
+)
+
+func TestMockStore_GetAccounts(t *testing.T) {
+	store := NewMockStore()
+	ctx := context.Background()
+
+	accounts, err := store.GetAccounts(ctx)
+	if err != nil {
+		t.Fatalf("GetAccounts() error = %v", err)
+	}
+
+	if len(accounts) != 2 {
+		t.Errorf("Expected 2 accounts, got %d", len(accounts))
+	}
+}
+
+func TestMockStore_GetAccount(t *testing.T) {
+	store := NewMockStore()
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		id      uuid.UUID
+		wantErr error
+	}{
+		{
+			name:    "existing account",
+			id:      checkingID,
+			wantErr: nil,
+		},
+		{
+			name:    "non-existing account",
+			id:      uuid.MustParse("99999999-9999-9999-9999-999999999999"),
+			wantErr: ErrAccountNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			account, err := store.GetAccount(ctx, tt.id)
+			if err != tt.wantErr {
+				t.Errorf("GetAccount() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr == nil && account == nil {
+				t.Error("GetAccount() returned nil account for existing ID")
+			}
+		})
+	}
+}
+
+func TestMockStore_CreateTransfer(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		request TransferRequest
+		wantErr error
+	}{
+		{
+			name: "valid transfer",
+			request: TransferRequest{
+				FromAccount: checkingID,
+				ToAccount:   savingsID,
+				Amount:      decimal.NewFromFloat(100.00),
+				Description: "Test transfer",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "insufficient funds",
+			request: TransferRequest{
+				FromAccount: checkingID,
+				ToAccount:   savingsID,
+				Amount:      decimal.NewFromFloat(10000.00),
+				Description: "Too much",
+			},
+			wantErr: ErrInsufficientFunds,
+		},
+		{
+			name: "non-existing from account",
+			request: TransferRequest{
+				FromAccount: uuid.MustParse("99999999-9999-9999-9999-999999999999"),
+				ToAccount:   savingsID,
+				Amount:      decimal.NewFromFloat(100.00),
+			},
+			wantErr: ErrAccountNotFound,
+		},
+		{
+			name: "non-existing to account",
+			request: TransferRequest{
+				FromAccount: checkingID,
+				ToAccount:   uuid.MustParse("99999999-9999-9999-9999-999999999999"),
+				Amount:      decimal.NewFromFloat(100.00),
+			},
+			wantErr: ErrAccountNotFound,
+		},
+		{
+			name: "same account",
+			request: TransferRequest{
+				FromAccount: checkingID,
+				ToAccount:   checkingID,
+				Amount:      decimal.NewFromFloat(100.00),
+			},
+			wantErr: ErrSameAccount,
+		},
+		{
+			name: "zero amount",
+			request: TransferRequest{
+				FromAccount: checkingID,
+				ToAccount:   savingsID,
+				Amount:      decimal.Zero,
+			},
+			wantErr: ErrInvalidAmount,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a fresh store for each test
+			store := NewMockStore()
+
+			transaction, err := store.CreateTransfer(ctx, tt.request)
+			if err != tt.wantErr {
+				t.Errorf("CreateTransfer() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr == nil {
+				if transaction == nil {
+					t.Error("CreateTransfer() returned nil transaction for valid request")
+				} else {
+					if !transaction.Amount.Equal(tt.request.Amount) {
+						t.Errorf("Transaction amount = %s, want %s", transaction.Amount, tt.request.Amount)
+					}
+					if transaction.FromAccount != tt.request.FromAccount {
+						t.Errorf("Transaction FromAccount = %s, want %s", transaction.FromAccount, tt.request.FromAccount)
+					}
+					if transaction.ToAccount != tt.request.ToAccount {
+						t.Errorf("Transaction ToAccount = %s, want %s", transaction.ToAccount, tt.request.ToAccount)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestMockStore_CreateTransfer_UpdatesBalances(t *testing.T) {
+	store := NewMockStore()
+	ctx := context.Background()
+
+	// Get initial balances
+	checkingBefore, _ := store.GetAccount(ctx, checkingID)
+	savingsBefore, _ := store.GetAccount(ctx, savingsID)
+
+	transferAmount := decimal.NewFromFloat(500.00)
+
+	// Perform transfer
+	_, err := store.CreateTransfer(ctx, TransferRequest{
+		FromAccount: checkingID,
+		ToAccount:   savingsID,
+		Amount:      transferAmount,
+	})
+	if err != nil {
+		t.Fatalf("CreateTransfer() error = %v", err)
+	}
+
+	// Check balances after transfer
+	checkingAfter, _ := store.GetAccount(ctx, checkingID)
+	savingsAfter, _ := store.GetAccount(ctx, savingsID)
+
+	expectedCheckingBalance := checkingBefore.Balance.Sub(transferAmount)
+	expectedSavingsBalance := savingsBefore.Balance.Add(transferAmount)
+
+	if !checkingAfter.Balance.Equal(expectedCheckingBalance) {
+		t.Errorf("Checking balance = %s, want %s", checkingAfter.Balance, expectedCheckingBalance)
+	}
+
+	if !savingsAfter.Balance.Equal(expectedSavingsBalance) {
+		t.Errorf("Savings balance = %s, want %s", savingsAfter.Balance, expectedSavingsBalance)
+	}
+}
+
+func TestMockStore_GetTransactions(t *testing.T) {
+	store := NewMockStore()
+	ctx := context.Background()
+
+	// Initially no transactions
+	transactions, err := store.GetTransactions(ctx)
+	if err != nil {
+		t.Fatalf("GetTransactions() error = %v", err)
+	}
+	if len(transactions) != 0 {
+		t.Errorf("Expected 0 transactions, got %d", len(transactions))
+	}
+
+	// Create a transfer
+	_, err = store.CreateTransfer(ctx, TransferRequest{
+		FromAccount: checkingID,
+		ToAccount:   savingsID,
+		Amount:      decimal.NewFromFloat(100.00),
+	})
+	if err != nil {
+		t.Fatalf("CreateTransfer() error = %v", err)
+	}
+
+	// Should now have 1 transaction
+	transactions, err = store.GetTransactions(ctx)
+	if err != nil {
+		t.Fatalf("GetTransactions() error = %v", err)
+	}
+	if len(transactions) != 1 {
+		t.Errorf("Expected 1 transaction, got %d", len(transactions))
+	}
+}
+
+func TestMockStore_GetTransaction(t *testing.T) {
+	store := NewMockStore()
+	ctx := context.Background()
+
+	// Create a transfer
+	created, err := store.CreateTransfer(ctx, TransferRequest{
+		FromAccount: checkingID,
+		ToAccount:   savingsID,
+		Amount:      decimal.NewFromFloat(100.00),
+	})
+	if err != nil {
+		t.Fatalf("CreateTransfer() error = %v", err)
+	}
+
+	// Get the transaction
+	retrieved, err := store.GetTransaction(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("GetTransaction() error = %v", err)
+	}
+
+	if retrieved.ID != created.ID {
+		t.Errorf("GetTransaction() ID = %s, want %s", retrieved.ID, created.ID)
+	}
+
+	// Try to get non-existing transaction
+	_, err = store.GetTransaction(ctx, uuid.MustParse("99999999-9999-9999-9999-999999999999"))
+	if err != ErrTransactionNotFound {
+		t.Errorf("GetTransaction() error = %v, want %v", err, ErrTransactionNotFound)
+	}
+}
+
+func TestMockStore_Reset(t *testing.T) {
+	store := NewMockStore()
+	ctx := context.Background()
+
+	// Make a transfer
+	_, err := store.CreateTransfer(ctx, TransferRequest{
+		FromAccount: checkingID,
+		ToAccount:   savingsID,
+		Amount:      decimal.NewFromFloat(1000.00),
+	})
+	if err != nil {
+		t.Fatalf("CreateTransfer() error = %v", err)
+	}
+
+	// Reset the store
+	store.Reset()
+
+	// Check balances are reset
+	checking, _ := store.GetAccount(ctx, checkingID)
+	if !checking.Balance.Equal(decimal.NewFromFloat(5000.00)) {
+		t.Errorf("After reset, Checking balance = %s, want 5000.00", checking.Balance)
+	}
+
+	// Check transactions are cleared
+	transactions, _ := store.GetTransactions(ctx)
+	if len(transactions) != 0 {
+		t.Errorf("After reset, expected 0 transactions, got %d", len(transactions))
+	}
+}


### PR DESCRIPTION
## Summary

Implements Issue #30 for the TrustBank demo application.

- Add `Account` and `Transaction` models with `decimal.Decimal` for precise money handling
- Define `Store` interface for testability and flexibility
- Implement `PostgresStore` with X.509 certificate authentication support for SPIFFE integration
- Implement `MockStore` for unit testing without database dependencies
- Add comprehensive unit tests for models and store operations
- Add PostgreSQL schema (`deploy/postgresql/init-trustbank.sql`) with seed data

## Test plan

- [x] All unit tests pass (`go test ./pkg/ledger/...`)
- [ ] PostgreSQL integration tested with real database (deferred to integration phase)

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)