### PR TITLE
Add ledger service HTTP handlers and SPIFFE mTLS server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,8 @@ publish:
 
 # ==================== Docker Compose Development Environment ====================
 COMPOSE_DIR := deploy/docker-compose
-COMPOSE := docker compose -f $(COMPOSE_DIR)/docker-compose.yaml
+# Support both old (docker-compose) and new (docker compose) commands
+COMPOSE := $(shell if command -v docker-compose >/dev/null 2>&1; then echo "docker-compose -f $(COMPOSE_DIR)/docker-compose.yaml"; else echo "docker compose -f $(COMPOSE_DIR)/docker-compose.yaml"; fi)
 
 .PHONY: dev-up # Start the development environment with SPIRE and PostgreSQL
 dev-up:

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,26 @@
-.DEFAULT_GOAL := build
+.DEFAULT_GOAL := help
 
 IMAGE_NAME ?= mattiasgees/spiffe-demo:latest
 
-.PHONY: test
+.PHONY: help # Show this help message
+help:
+	@echo "SPIFFE Demo - Available Commands"
+	@echo "================================="
+	@echo ""
+	@echo "Build & Publish:"
+	@grep -E '^\.PHONY: (build|publish|test) ' $(MAKEFILE_LIST) | sed 's/\.PHONY: /  make /' | sed 's/ # /\t- /'
+	@echo ""
+	@echo "Development Environment:"
+	@grep -E '^\.PHONY: dev-' $(MAKEFILE_LIST) | sed 's/\.PHONY: /  make /' | sed 's/ # /\t- /'
+	@grep -E '^\.PHONY: test-client' $(MAKEFILE_LIST) | sed 's/\.PHONY: /  make /' | sed 's/ # /\t- /'
+	@echo ""
+	@echo "Quick Start:"
+	@echo "  make dev-up      # Start SPIRE + PostgreSQL + Ledger"
+	@echo "  make dev-logs    # Watch the logs"
+	@echo "  make test-client # Start test client container"
+	@echo "  make dev-down    # Stop everything"
+
+.PHONY: test # Run unit tests
 test:
 	go test -v ./...
 INIT_IMAGE_NAME ?= mattiasgees/spiffe-demo-init:latest

--- a/Makefile
+++ b/Makefile
@@ -54,3 +54,70 @@ publish:
 		--output "type=docker,push=true" \
 		--tag $(SPIFFE_GCP_PROXY_IMAGE_NAME) \
 		./deploy/spiffe-gcp-proxy
+
+# ==================== Docker Compose Development Environment ====================
+COMPOSE_DIR := deploy/docker-compose
+COMPOSE := docker compose -f $(COMPOSE_DIR)/docker-compose.yaml
+
+.PHONY: dev-up # Start the development environment with SPIRE and PostgreSQL
+dev-up:
+	@echo "Starting SPIFFE development environment..."
+	$(COMPOSE) up -d
+	@echo ""
+	@echo "Development environment is starting..."
+	@echo "  - SPIRE Server: managing workload identities"
+	@echo "  - SPIRE Agent: providing workload API"
+	@echo "  - PostgreSQL: database with certificate authentication"
+	@echo "  - Ledger Service: https://localhost:8443"
+	@echo ""
+	@echo "Use 'make dev-logs' to view logs"
+	@echo "Use 'make dev-down' to stop the environment"
+
+.PHONY: dev-down # Stop and clean up the development environment
+dev-down:
+	@echo "Stopping development environment..."
+	$(COMPOSE) down -v
+	@echo "Development environment stopped and volumes removed."
+
+.PHONY: dev-logs # View logs from all services
+dev-logs:
+	$(COMPOSE) logs -f
+
+.PHONY: dev-status # Show status of all services
+dev-status:
+	$(COMPOSE) ps
+
+.PHONY: dev-restart # Restart the development environment
+dev-restart: dev-down dev-up
+
+.PHONY: dev-build # Rebuild the ledger service and restart
+dev-build:
+	@echo "Rebuilding ledger service..."
+	$(COMPOSE) build ledger
+	$(COMPOSE) up -d ledger
+	@echo "Ledger service rebuilt and restarted."
+
+.PHONY: test-client # Start test client for manual testing
+test-client:
+	@echo "Starting test client..."
+	$(COMPOSE) --profile test up -d test-client
+	@echo ""
+	@echo "Test client is running. Connect with:"
+	@echo "  docker compose -f $(COMPOSE_DIR)/docker-compose.yaml exec test-client /bin/sh"
+	@echo ""
+	@echo "Example commands inside the container:"
+	@echo "  # List accounts"
+	@echo '  curl -k https://ledger:8443/api/accounts'
+	@echo ""
+	@echo "  # Create a transfer"
+	@echo '  curl -k -X POST https://ledger:8443/api/transfers \'
+	@echo '    -H "Content-Type: application/json" \'
+	@echo '    -d '\''{"from_account":"11111111-1111-1111-1111-111111111111","to_account":"22222222-2222-2222-2222-222222222222","amount":"100.00"}'\'
+
+.PHONY: dev-shell # Open a shell in the ledger container
+dev-shell:
+	$(COMPOSE) exec ledger /bin/sh
+
+.PHONY: dev-psql # Connect to PostgreSQL
+dev-psql:
+	$(COMPOSE) exec postgres psql -U postgres -d trustbank

--- a/cmd/ledger.go
+++ b/cmd/ledger.go
@@ -1,0 +1,104 @@
+/*
+Copyright © 2024 Mattias Gees mattias.gees@venafi.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"context"
+	"log"
+
+	"github.com/mattiasgees/spiffe-demo/pkg/ledger"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+var ledgerCmd = &cobra.Command{
+	Use:   "ledger",
+	Short: "TrustBank ledger service",
+	Long: `The ledger service provides a secure banking API for the TrustBank demo.
+
+It exposes REST endpoints for managing accounts and transfers, secured with
+SPIFFE mTLS authentication. Only clients with authorized SPIFFE IDs can connect.
+
+Endpoints:
+  GET  /api/accounts         - List all accounts with balances
+  GET  /api/accounts/{id}    - Get a specific account
+  POST /api/transfers        - Create a transfer between accounts
+  GET  /api/transactions     - List all transactions
+  GET  /api/transactions/{id} - Get a specific transaction
+  GET  /health               - Health check endpoint`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Get configuration
+		serverAddress := viper.GetString("server.address")
+		spiffeAuthz := viper.GetString("spiffe.authorized_id")
+
+		// Determine storage backend
+		var store ledger.Store
+		useMock := viper.GetBool("ledger.use_mock")
+
+		if useMock {
+			log.Println("Using mock store (in-memory)")
+			store = ledger.NewMockStore()
+		} else {
+			// Use PostgreSQL store
+			cfg := ledger.PostgresConfig{
+				Host:        viper.GetString("ledger.postgresql.host"),
+				Port:        viper.GetInt("ledger.postgresql.port"),
+				User:        viper.GetString("ledger.postgresql.user"),
+				Database:    viper.GetString("ledger.postgresql.database"),
+				SSLMode:     viper.GetString("ledger.postgresql.ssl_mode"),
+				SSLCert:     viper.GetString("ledger.postgresql.ssl_cert"),
+				SSLKey:      viper.GetString("ledger.postgresql.ssl_key"),
+				SSLRootCert: viper.GetString("ledger.postgresql.ssl_root_cert"),
+			}
+
+			pgStore, err := ledger.NewPostgresStore(context.Background(), cfg)
+			if err != nil {
+				log.Fatalf("Failed to connect to PostgreSQL: %v", err)
+			}
+			defer pgStore.Close()
+			store = pgStore
+		}
+
+		// Start the server
+		ledger.StartServer(spiffeAuthz, serverAddress, store)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(ledgerCmd)
+
+	// Ledger-specific flags
+	ledgerCmd.Flags().Bool("use-mock", false, "Use in-memory mock store instead of PostgreSQL")
+	ledgerCmd.Flags().String("postgresql-host", "localhost", "PostgreSQL host")
+	ledgerCmd.Flags().Int("postgresql-port", 5432, "PostgreSQL port")
+	ledgerCmd.Flags().String("postgresql-user", "spiffe-demo-ledger", "PostgreSQL user")
+	ledgerCmd.Flags().String("postgresql-database", "trustbank", "PostgreSQL database")
+	ledgerCmd.Flags().String("postgresql-ssl-mode", "require", "PostgreSQL SSL mode")
+	ledgerCmd.Flags().String("postgresql-ssl-cert", "", "Path to client SSL certificate")
+	ledgerCmd.Flags().String("postgresql-ssl-key", "", "Path to client SSL key")
+	ledgerCmd.Flags().String("postgresql-ssl-root-cert", "", "Path to SSL root certificate")
+
+	// Bind flags to viper
+	viper.BindPFlag("ledger.use_mock", ledgerCmd.Flags().Lookup("use-mock"))
+	viper.BindPFlag("ledger.postgresql.host", ledgerCmd.Flags().Lookup("postgresql-host"))
+	viper.BindPFlag("ledger.postgresql.port", ledgerCmd.Flags().Lookup("postgresql-port"))
+	viper.BindPFlag("ledger.postgresql.user", ledgerCmd.Flags().Lookup("postgresql-user"))
+	viper.BindPFlag("ledger.postgresql.database", ledgerCmd.Flags().Lookup("postgresql-database"))
+	viper.BindPFlag("ledger.postgresql.ssl_mode", ledgerCmd.Flags().Lookup("postgresql-ssl-mode"))
+	viper.BindPFlag("ledger.postgresql.ssl_cert", ledgerCmd.Flags().Lookup("postgresql-ssl-cert"))
+	viper.BindPFlag("ledger.postgresql.ssl_key", ledgerCmd.Flags().Lookup("postgresql-ssl-key"))
+	viper.BindPFlag("ledger.postgresql.ssl_root_cert", ledgerCmd.Flags().Lookup("postgresql-ssl-root-cert"))
+}

--- a/cmd/ledger.go
+++ b/cmd/ledger.go
@@ -22,6 +22,7 @@ import (
 	"github.com/mattiasgees/spiffe-demo/pkg/ledger"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
 )
 
 var ledgerCmd = &cobra.Command{
@@ -32,6 +33,10 @@ var ledgerCmd = &cobra.Command{
 It exposes REST endpoints for managing accounts and transfers, secured with
 SPIFFE mTLS authentication. Only clients with authorized SPIFFE IDs can connect.
 
+The service uses SPIFFE X.509-SVIDs for:
+  - Server mTLS authentication (incoming client connections)
+  - PostgreSQL client authentication (database connections)
+
 Endpoints:
   GET  /api/accounts         - List all accounts with balances
   GET  /api/accounts/{id}    - Get a specific account
@@ -40,6 +45,8 @@ Endpoints:
   GET  /api/transactions/{id} - Get a specific transaction
   GET  /health               - Health check endpoint`,
 	Run: func(cmd *cobra.Command, args []string) {
+		ctx := context.Background()
+
 		// Get configuration
 		serverAddress := viper.GetString("server.address")
 		spiffeAuthz := viper.GetString("spiffe.authorized_id")
@@ -52,19 +59,33 @@ Endpoints:
 			log.Println("Using mock store (in-memory)")
 			store = ledger.NewMockStore()
 		} else {
-			// Use PostgreSQL store
+			// SPIFFE CONCEPT: Unified Identity for All Connections
+			// The X509Source provides the service's SPIFFE identity which is used for:
+			// 1. mTLS server authentication (clients connecting to this service)
+			// 2. mTLS client authentication (this service connecting to PostgreSQL)
+			// This demonstrates how a single SPIFFE identity can secure multiple
+			// connection types without managing separate certificates.
+			source, err := workloadapi.NewX509Source(ctx)
+			if err != nil {
+				log.Fatalf("Failed to create X509Source: %v", err)
+			}
+			defer source.Close()
+
+			svid, err := source.GetX509SVID()
+			if err != nil {
+				log.Fatalf("Failed to get X509-SVID: %v", err)
+			}
+			log.Printf("Using SPIFFE identity: %s", svid.ID.String())
+
+			// Use PostgreSQL store with SPIFFE authentication
 			cfg := ledger.PostgresConfig{
-				Host:        viper.GetString("ledger.postgresql.host"),
-				Port:        viper.GetInt("ledger.postgresql.port"),
-				User:        viper.GetString("ledger.postgresql.user"),
-				Database:    viper.GetString("ledger.postgresql.database"),
-				SSLMode:     viper.GetString("ledger.postgresql.ssl_mode"),
-				SSLCert:     viper.GetString("ledger.postgresql.ssl_cert"),
-				SSLKey:      viper.GetString("ledger.postgresql.ssl_key"),
-				SSLRootCert: viper.GetString("ledger.postgresql.ssl_root_cert"),
+				Host:     viper.GetString("ledger.postgresql.host"),
+				Port:     viper.GetInt("ledger.postgresql.port"),
+				User:     viper.GetString("ledger.postgresql.user"),
+				Database: viper.GetString("ledger.postgresql.database"),
 			}
 
-			pgStore, err := ledger.NewPostgresStore(context.Background(), cfg)
+			pgStore, err := ledger.NewPostgresStore(ctx, cfg, source)
 			if err != nil {
 				log.Fatalf("Failed to connect to PostgreSQL: %v", err)
 			}
@@ -86,10 +107,6 @@ func init() {
 	ledgerCmd.Flags().Int("postgresql-port", 5432, "PostgreSQL port")
 	ledgerCmd.Flags().String("postgresql-user", "spiffe-demo-ledger", "PostgreSQL user")
 	ledgerCmd.Flags().String("postgresql-database", "trustbank", "PostgreSQL database")
-	ledgerCmd.Flags().String("postgresql-ssl-mode", "require", "PostgreSQL SSL mode")
-	ledgerCmd.Flags().String("postgresql-ssl-cert", "", "Path to client SSL certificate")
-	ledgerCmd.Flags().String("postgresql-ssl-key", "", "Path to client SSL key")
-	ledgerCmd.Flags().String("postgresql-ssl-root-cert", "", "Path to SSL root certificate")
 
 	// Bind flags to viper
 	viper.BindPFlag("ledger.use_mock", ledgerCmd.Flags().Lookup("use-mock"))
@@ -97,8 +114,4 @@ func init() {
 	viper.BindPFlag("ledger.postgresql.port", ledgerCmd.Flags().Lookup("postgresql-port"))
 	viper.BindPFlag("ledger.postgresql.user", ledgerCmd.Flags().Lookup("postgresql-user"))
 	viper.BindPFlag("ledger.postgresql.database", ledgerCmd.Flags().Lookup("postgresql-database"))
-	viper.BindPFlag("ledger.postgresql.ssl_mode", ledgerCmd.Flags().Lookup("postgresql-ssl-mode"))
-	viper.BindPFlag("ledger.postgresql.ssl_cert", ledgerCmd.Flags().Lookup("postgresql-ssl-cert"))
-	viper.BindPFlag("ledger.postgresql.ssl_key", ledgerCmd.Flags().Lookup("postgresql-ssl-key"))
-	viper.BindPFlag("ledger.postgresql.ssl_root_cert", ledgerCmd.Flags().Lookup("postgresql-ssl-root-cert"))
 }

--- a/cmd/ledger.go
+++ b/cmd/ledger.go
@@ -78,10 +78,10 @@ Endpoints:
 			log.Printf("Using SPIFFE identity: %s", svid.ID.String())
 
 			// Use PostgreSQL store with SPIFFE authentication
+			// Note: Username is automatically extracted from the SVID's Common Name
 			cfg := ledger.PostgresConfig{
 				Host:     viper.GetString("ledger.postgresql.host"),
 				Port:     viper.GetInt("ledger.postgresql.port"),
-				User:     viper.GetString("ledger.postgresql.user"),
 				Database: viper.GetString("ledger.postgresql.database"),
 			}
 
@@ -102,16 +102,15 @@ func init() {
 	rootCmd.AddCommand(ledgerCmd)
 
 	// Ledger-specific flags
+	// Note: PostgreSQL username is derived from the SPIFFE SVID's Common Name
 	ledgerCmd.Flags().Bool("use-mock", false, "Use in-memory mock store instead of PostgreSQL")
 	ledgerCmd.Flags().String("postgresql-host", "localhost", "PostgreSQL host")
 	ledgerCmd.Flags().Int("postgresql-port", 5432, "PostgreSQL port")
-	ledgerCmd.Flags().String("postgresql-user", "spiffe-demo-ledger", "PostgreSQL user")
 	ledgerCmd.Flags().String("postgresql-database", "trustbank", "PostgreSQL database")
 
 	// Bind flags to viper
 	viper.BindPFlag("ledger.use_mock", ledgerCmd.Flags().Lookup("use-mock"))
 	viper.BindPFlag("ledger.postgresql.host", ledgerCmd.Flags().Lookup("postgresql-host"))
 	viper.BindPFlag("ledger.postgresql.port", ledgerCmd.Flags().Lookup("postgresql-port"))
-	viper.BindPFlag("ledger.postgresql.user", ledgerCmd.Flags().Lookup("postgresql-user"))
 	viper.BindPFlag("ledger.postgresql.database", ledgerCmd.Flags().Lookup("postgresql-database"))
 }

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -82,24 +82,15 @@ ledger:
     # PostgreSQL server port
     # CLI: --postgresql-port, Env: SPIFFE_DEMO_LEDGER_POSTGRESQL_PORT
     port: 5432
-    # PostgreSQL username (should match CN in client certificate for X.509 auth)
+    # PostgreSQL username (should match SPIFFE ID for certificate-based auth)
     # CLI: --postgresql-user, Env: SPIFFE_DEMO_LEDGER_POSTGRESQL_USER
     user: "spiffe-demo-ledger"
     # PostgreSQL database name
     # CLI: --postgresql-database, Env: SPIFFE_DEMO_LEDGER_POSTGRESQL_DATABASE
     database: "trustbank"
-    # SSL mode (disable, require, verify-ca, verify-full)
-    # CLI: --postgresql-ssl-mode, Env: SPIFFE_DEMO_LEDGER_POSTGRESQL_SSL_MODE
-    ssl_mode: "require"
-    # Path to client SSL certificate (for X.509 authentication)
-    # CLI: --postgresql-ssl-cert, Env: SPIFFE_DEMO_LEDGER_POSTGRESQL_SSL_CERT
-    ssl_cert: "/certs/client.crt"
-    # Path to client SSL key
-    # CLI: --postgresql-ssl-key, Env: SPIFFE_DEMO_LEDGER_POSTGRESQL_SSL_KEY
-    ssl_key: "/certs/client.key"
-    # Path to CA certificate for verifying server
-    # CLI: --postgresql-ssl-root-cert, Env: SPIFFE_DEMO_LEDGER_POSTGRESQL_SSL_ROOT_CERT
-    ssl_root_cert: "/certs/ca.crt"
+    # Note: TLS/SSL is handled automatically via SPIFFE X.509-SVIDs.
+    # The service obtains its certificate from the SPIFFE Workload API
+    # and uses it for mTLS authentication to PostgreSQL.
 
 # Backend and httpservice commands use only the global settings above
 # (server.address and spiffe.authorized_id)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -69,5 +69,37 @@ customer:
     # CLI: --postgresql-user, Env: SPIFFE_DEMO_CUSTOMER_POSTGRESQL_USER
     user: "spiffe_user"
 
+# Ledger service specific settings (TrustBank banking API)
+ledger:
+  # Use in-memory mock store instead of PostgreSQL (useful for development)
+  # CLI: --use-mock, Env: SPIFFE_DEMO_LEDGER_USE_MOCK
+  use_mock: false
+
+  postgresql:
+    # PostgreSQL server hostname
+    # CLI: --postgresql-host, Env: SPIFFE_DEMO_LEDGER_POSTGRESQL_HOST
+    host: "postgres.local"
+    # PostgreSQL server port
+    # CLI: --postgresql-port, Env: SPIFFE_DEMO_LEDGER_POSTGRESQL_PORT
+    port: 5432
+    # PostgreSQL username (should match CN in client certificate for X.509 auth)
+    # CLI: --postgresql-user, Env: SPIFFE_DEMO_LEDGER_POSTGRESQL_USER
+    user: "spiffe-demo-ledger"
+    # PostgreSQL database name
+    # CLI: --postgresql-database, Env: SPIFFE_DEMO_LEDGER_POSTGRESQL_DATABASE
+    database: "trustbank"
+    # SSL mode (disable, require, verify-ca, verify-full)
+    # CLI: --postgresql-ssl-mode, Env: SPIFFE_DEMO_LEDGER_POSTGRESQL_SSL_MODE
+    ssl_mode: "require"
+    # Path to client SSL certificate (for X.509 authentication)
+    # CLI: --postgresql-ssl-cert, Env: SPIFFE_DEMO_LEDGER_POSTGRESQL_SSL_CERT
+    ssl_cert: "/certs/client.crt"
+    # Path to client SSL key
+    # CLI: --postgresql-ssl-key, Env: SPIFFE_DEMO_LEDGER_POSTGRESQL_SSL_KEY
+    ssl_key: "/certs/client.key"
+    # Path to CA certificate for verifying server
+    # CLI: --postgresql-ssl-root-cert, Env: SPIFFE_DEMO_LEDGER_POSTGRESQL_SSL_ROOT_CERT
+    ssl_root_cert: "/certs/ca.crt"
+
 # Backend and httpservice commands use only the global settings above
 # (server.address and spiffe.authorized_id)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -82,15 +82,12 @@ ledger:
     # PostgreSQL server port
     # CLI: --postgresql-port, Env: SPIFFE_DEMO_LEDGER_POSTGRESQL_PORT
     port: 5432
-    # PostgreSQL username (should match SPIFFE ID for certificate-based auth)
-    # CLI: --postgresql-user, Env: SPIFFE_DEMO_LEDGER_POSTGRESQL_USER
-    user: "spiffe-demo-ledger"
     # PostgreSQL database name
     # CLI: --postgresql-database, Env: SPIFFE_DEMO_LEDGER_POSTGRESQL_DATABASE
     database: "trustbank"
-    # Note: TLS/SSL is handled automatically via SPIFFE X.509-SVIDs.
-    # The service obtains its certificate from the SPIFFE Workload API
-    # and uses it for mTLS authentication to PostgreSQL.
+    # Note: TLS/SSL and username are handled automatically via SPIFFE X.509-SVIDs.
+    # The service obtains its certificate from the SPIFFE Workload API and uses
+    # the certificate's Common Name (CN) as the PostgreSQL username.
 
 # Backend and httpservice commands use only the global settings above
 # (server.address and spiffe.authorized_id)

--- a/deploy/docker-compose/docker-compose.yaml
+++ b/deploy/docker-compose/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # SPIRE Server - the central authority that issues identities
   spire-server:

--- a/deploy/docker-compose/docker-compose.yaml
+++ b/deploy/docker-compose/docker-compose.yaml
@@ -1,0 +1,180 @@
+version: '3.8'
+
+services:
+  # SPIRE Server - the central authority that issues identities
+  spire-server:
+    image: ghcr.io/spiffe/spire-server:1.9.6
+    hostname: spire-server
+    volumes:
+      - ./spire/server.conf:/opt/spire/conf/server/server.conf:ro
+      - spire-data:/opt/spire/data
+      - spire-socket:/opt/spire/sockets
+      - join-token:/opt/spire/token
+    command: ["-config", "/opt/spire/conf/server/server.conf"]
+    healthcheck:
+      test: ["CMD", "/opt/spire/bin/spire-server", "healthcheck", "-socketPath", "/opt/spire/sockets/api.sock"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  # Generate join token after server is healthy
+  token-generator:
+    image: ghcr.io/spiffe/spire-server:1.9.6
+    depends_on:
+      spire-server:
+        condition: service_healthy
+    volumes:
+      - spire-socket:/opt/spire/sockets
+      - join-token:/opt/spire/token
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        TOKEN=$$(/opt/spire/bin/spire-server token generate -socketPath /opt/spire/sockets/api.sock -spiffeID spiffe://example.org/spire-agent -ttl 3600 | awk '{print $$2}')
+        echo "$$TOKEN" > /opt/spire/token/join-token
+        echo "Join token generated: $$TOKEN"
+    restart: "no"
+
+  # SPIRE Agent - runs on each node and provides workload API
+  spire-agent:
+    image: ghcr.io/spiffe/spire-agent:1.9.6
+    hostname: spire-agent
+    depends_on:
+      token-generator:
+        condition: service_completed_successfully
+    pid: "host"
+    volumes:
+      - ./spire/agent.conf:/opt/spire/conf/agent/agent.conf:ro
+      - spire-socket:/opt/spire/sockets
+      - workload-socket:/opt/spire/workload-sockets
+      - join-token:/opt/spire/token:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        TOKEN=$$(cat /opt/spire/token/join-token)
+        echo "Using join token: $$TOKEN"
+        /opt/spire/bin/spire-agent run -config /opt/spire/conf/agent/agent.conf -joinToken "$$TOKEN"
+    healthcheck:
+      test: ["CMD", "/opt/spire/bin/spire-agent", "healthcheck", "-socketPath", "/opt/spire/workload-sockets/agent.sock"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+
+  # Registration helper - creates SPIRE entries after agent is ready
+  spire-register:
+    image: ghcr.io/spiffe/spire-server:1.9.6
+    depends_on:
+      spire-agent:
+        condition: service_healthy
+    volumes:
+      - spire-socket:/opt/spire/sockets
+      - ./spire/registration.sh:/opt/spire/registration.sh:ro
+    entrypoint: ["/bin/sh", "/opt/spire/registration.sh"]
+    restart: "no"
+
+  # SPIFFE Helper for PostgreSQL - fetches SVIDs and writes to disk
+  postgres-spiffe-helper:
+    image: ghcr.io/spiffe/spiffe-helper:0.8.0
+    hostname: postgres-spiffe-helper
+    depends_on:
+      spire-register:
+        condition: service_completed_successfully
+    environment:
+      SPIFFE_ENDPOINT_SOCKET: unix:///opt/spire/workload-sockets/agent.sock
+    volumes:
+      - workload-socket:/opt/spire/workload-sockets:ro
+      - ./spire/postgres-helper.conf:/etc/spiffe-helper.conf:ro
+      - postgres-certs:/certs
+    command: ["-config", "/etc/spiffe-helper.conf"]
+    healthcheck:
+      test: ["CMD", "test", "-f", "/certs/svid.pem"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+    labels:
+      - "com.docker.compose.service=postgres-spiffe-helper"
+
+  # PostgreSQL with certificate authentication
+  postgres:
+    image: postgres:16-alpine
+    hostname: postgres
+    depends_on:
+      postgres-spiffe-helper:
+        condition: service_healthy
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: trustbank
+    volumes:
+      - ./postgres/init-db.sql:/docker-entrypoint-initdb.d/01-init-db.sql:ro
+      - ./postgres/pg_hba.conf:/etc/postgresql/pg_hba.conf:ro
+      - postgres-data:/var/lib/postgresql/data
+      - postgres-certs:/certs:ro
+    command: >
+      postgres
+      -c ssl=on
+      -c ssl_cert_file=/certs/svid.pem
+      -c ssl_key_file=/certs/svid_key.pem
+      -c ssl_ca_file=/certs/bundle.pem
+      -c hba_file=/etc/postgresql/pg_hba.conf
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d trustbank"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+    labels:
+      - "com.docker.compose.service=postgres"
+
+  # TrustBank Ledger Service
+  ledger:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    depends_on:
+      postgres:
+        condition: service_healthy
+      spire-agent:
+        condition: service_healthy
+    environment:
+      SPIFFE_ENDPOINT_SOCKET: unix:///opt/spire/workload-sockets/agent.sock
+    volumes:
+      - workload-socket:/opt/spire/workload-sockets:ro
+    command: >
+      ledger
+      --server-address 0.0.0.0:8443
+      --authorized-spiffe spiffe://example.org/customer
+      --postgresql-host postgres
+      --postgresql-database trustbank
+    ports:
+      - "8443:8443"
+    labels:
+      - "com.docker.compose.service=ledger"
+
+  # Test client - simulates the customer service
+  test-client:
+    build:
+      context: ../..
+      dockerfile: Dockerfile
+    depends_on:
+      ledger:
+        condition: service_started
+      spire-agent:
+        condition: service_healthy
+    environment:
+      SPIFFE_ENDPOINT_SOCKET: unix:///opt/spire/workload-sockets/agent.sock
+      LEDGER_URL: https://ledger:8443
+    volumes:
+      - workload-socket:/opt/spire/workload-sockets:ro
+    entrypoint: ["/bin/sh", "-c", "echo 'Test client ready. Use: make test-client' && sleep infinity"]
+    labels:
+      - "com.docker.compose.service=test-client"
+    profiles:
+      - test
+
+volumes:
+  spire-data:
+  spire-socket:
+  workload-socket:
+  join-token:
+  postgres-data:
+  postgres-certs:

--- a/deploy/docker-compose/postgres/init-db.sql
+++ b/deploy/docker-compose/postgres/init-db.sql
@@ -1,0 +1,52 @@
+-- TrustBank database initialization for Docker Compose testing
+-- This script runs after PostgreSQL starts
+
+-- Create the ledger user (matches the SPIFFE ID path component)
+-- The CN in the X.509-SVID will be "ledger" based on spiffe://example.org/ledger
+CREATE USER ledger;
+
+-- Grant permissions to the ledger user
+GRANT CONNECT ON DATABASE trustbank TO ledger;
+
+-- Create tables in trustbank database
+\c trustbank
+
+-- Accounts table
+CREATE TABLE IF NOT EXISTS accounts (
+    id UUID PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    balance DECIMAL(15,2) NOT NULL DEFAULT 0.00,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    CONSTRAINT balance_non_negative CHECK (balance >= 0)
+);
+
+-- Transactions table
+CREATE TABLE IF NOT EXISTS transactions (
+    id UUID PRIMARY KEY,
+    from_account UUID NOT NULL REFERENCES accounts(id),
+    to_account UUID NOT NULL REFERENCES accounts(id),
+    amount DECIMAL(15,2) NOT NULL,
+    description VARCHAR(255),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    CONSTRAINT amount_positive CHECK (amount > 0),
+    CONSTRAINT different_accounts CHECK (from_account != to_account)
+);
+
+-- Indexes for better query performance
+CREATE INDEX IF NOT EXISTS idx_transactions_from_account ON transactions(from_account);
+CREATE INDEX IF NOT EXISTS idx_transactions_to_account ON transactions(to_account);
+CREATE INDEX IF NOT EXISTS idx_transactions_created_at ON transactions(created_at DESC);
+
+-- Seed data: Create demo accounts
+INSERT INTO accounts (id, name, balance, created_at) VALUES
+    ('11111111-1111-1111-1111-111111111111', 'Checking', 5000.00, NOW()),
+    ('22222222-2222-2222-2222-222222222222', 'Savings', 5000.00, NOW())
+ON CONFLICT (id) DO NOTHING;
+
+-- Grant table permissions to ledger user
+GRANT SELECT, INSERT, UPDATE ON accounts TO ledger;
+GRANT SELECT, INSERT ON transactions TO ledger;
+
+-- Show confirmation
+\echo 'TrustBank database initialized successfully'
+\echo 'User "ledger" created with certificate authentication'

--- a/deploy/docker-compose/postgres/pg_hba.conf
+++ b/deploy/docker-compose/postgres/pg_hba.conf
@@ -1,0 +1,13 @@
+# PostgreSQL Client Authentication Configuration
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# Allow local connections without authentication (for admin)
+local   all             postgres                                trust
+local   all             all                                     trust
+
+# IPv4 local connections - require certificate authentication
+# The CN from the client certificate must match the database username
+hostssl all             all             0.0.0.0/0               cert
+
+# IPv6 local connections - require certificate authentication
+hostssl all             all             ::/0                    cert

--- a/deploy/docker-compose/spire/agent.conf
+++ b/deploy/docker-compose/spire/agent.conf
@@ -1,0 +1,32 @@
+agent {
+    data_dir = "/opt/spire/data/agent"
+    log_level = "INFO"
+    trust_domain = "example.org"
+    server_address = "spire-server"
+    server_port = "8081"
+
+    # Socket for workload API
+    socket_path = "/opt/spire/workload-sockets/agent.sock"
+
+    # Insecure bootstrap for demo purposes
+    # In production, use proper bootstrap with trust bundle
+    insecure_bootstrap = true
+}
+
+plugins {
+    KeyManager "disk" {
+        plugin_data {
+            directory = "/opt/spire/data/agent"
+        }
+    }
+
+    NodeAttestor "join_token" {
+        plugin_data {}
+    }
+
+    WorkloadAttestor "docker" {
+        plugin_data {
+            docker_socket_path = "/var/run/docker.sock"
+        }
+    }
+}

--- a/deploy/docker-compose/spire/postgres-helper.conf
+++ b/deploy/docker-compose/spire/postgres-helper.conf
@@ -1,0 +1,18 @@
+# SPIFFE Helper configuration for PostgreSQL
+# Fetches X.509-SVIDs from SPIRE and writes them to disk for PostgreSQL
+
+agent_address = "/opt/spire/workload-sockets/agent.sock"
+
+# Certificate output paths
+svid_file_name = "/certs/svid.pem"
+svid_key_file_name = "/certs/svid_key.pem"
+svid_bundle_file_name = "/certs/bundle.pem"
+
+# Renewal signal - not needed for PostgreSQL as it reads certs on connection
+# But we can use SIGHUP if needed
+# renew_signal = "SIGHUP"
+
+# Certificate permissions
+svid_file_mode = 0644
+svid_key_file_mode = 0600
+svid_bundle_file_mode = 0644

--- a/deploy/docker-compose/spire/registration.sh
+++ b/deploy/docker-compose/spire/registration.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+set -e
+
+echo "Waiting for SPIRE Server to be ready..."
+sleep 5
+
+SOCKET="/opt/spire/sockets/api.sock"
+
+echo "Creating registration entries..."
+
+# Register the ledger service
+# Uses docker workload attestor with compose service label
+/opt/spire/bin/spire-server entry create \
+    -socketPath "$SOCKET" \
+    -spiffeID spiffe://example.org/ledger \
+    -parentID spiffe://example.org/spire-agent \
+    -selector docker:label:com.docker.compose.service:ledger \
+    -x509SVIDTTL 3600 \
+    -dns ledger \
+    -dns localhost \
+    2>/dev/null || echo "Ledger entry may already exist"
+
+# Register the postgres spiffe-helper to get certs for PostgreSQL
+# The CN will be extracted from the SPIFFE ID path component
+/opt/spire/bin/spire-server entry create \
+    -socketPath "$SOCKET" \
+    -spiffeID spiffe://example.org/postgres \
+    -parentID spiffe://example.org/spire-agent \
+    -selector docker:label:com.docker.compose.service:postgres-spiffe-helper \
+    -x509SVIDTTL 3600 \
+    -dns postgres \
+    -dns localhost \
+    2>/dev/null || echo "Postgres entry may already exist"
+
+# Register the test client (simulating customer service)
+/opt/spire/bin/spire-server entry create \
+    -socketPath "$SOCKET" \
+    -spiffeID spiffe://example.org/customer \
+    -parentID spiffe://example.org/spire-agent \
+    -selector docker:label:com.docker.compose.service:test-client \
+    -x509SVIDTTL 3600 \
+    -dns test-client \
+    -dns localhost \
+    2>/dev/null || echo "Customer entry may already exist"
+
+echo ""
+echo "Listing all entries:"
+/opt/spire/bin/spire-server entry show -socketPath "$SOCKET"
+
+echo ""
+echo "Registration complete!"

--- a/deploy/docker-compose/spire/server.conf
+++ b/deploy/docker-compose/spire/server.conf
@@ -1,0 +1,31 @@
+server {
+    bind_address = "0.0.0.0"
+    bind_port = "8081"
+    trust_domain = "example.org"
+    data_dir = "/opt/spire/data/server"
+    log_level = "INFO"
+    ca_ttl = "24h"
+    default_x509_svid_ttl = "1h"
+
+    # Socket for CLI and agent connections
+    socket_path = "/opt/spire/sockets/api.sock"
+}
+
+plugins {
+    DataStore "sql" {
+        plugin_data {
+            database_type = "sqlite3"
+            connection_string = "/opt/spire/data/server/datastore.sqlite3"
+        }
+    }
+
+    KeyManager "disk" {
+        plugin_data {
+            keys_path = "/opt/spire/data/server/keys.json"
+        }
+    }
+
+    NodeAttestor "join_token" {
+        plugin_data {}
+    }
+}

--- a/deploy/postgresql/init-trustbank.sql
+++ b/deploy/postgresql/init-trustbank.sql
@@ -1,0 +1,42 @@
+-- TrustBank database schema
+-- This script initializes the database with the required tables and seed data.
+
+-- Create the trustbank database if it doesn't exist
+-- Note: This is handled separately in the init script
+
+-- Accounts table
+CREATE TABLE IF NOT EXISTS accounts (
+    id UUID PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    balance DECIMAL(15,2) NOT NULL DEFAULT 0.00,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    CONSTRAINT balance_non_negative CHECK (balance >= 0)
+);
+
+-- Transactions table
+CREATE TABLE IF NOT EXISTS transactions (
+    id UUID PRIMARY KEY,
+    from_account UUID NOT NULL REFERENCES accounts(id),
+    to_account UUID NOT NULL REFERENCES accounts(id),
+    amount DECIMAL(15,2) NOT NULL,
+    description VARCHAR(255),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    CONSTRAINT amount_positive CHECK (amount > 0),
+    CONSTRAINT different_accounts CHECK (from_account != to_account)
+);
+
+-- Indexes for better query performance
+CREATE INDEX IF NOT EXISTS idx_transactions_from_account ON transactions(from_account);
+CREATE INDEX IF NOT EXISTS idx_transactions_to_account ON transactions(to_account);
+CREATE INDEX IF NOT EXISTS idx_transactions_created_at ON transactions(created_at DESC);
+
+-- Seed data: Create demo accounts
+INSERT INTO accounts (id, name, balance, created_at) VALUES
+    ('11111111-1111-1111-1111-111111111111', 'Checking', 5000.00, NOW()),
+    ('22222222-2222-2222-2222-222222222222', 'Savings', 5000.00, NOW())
+ON CONFLICT (id) DO NOTHING;
+
+-- Grant permissions to the ledger service user
+-- Note: The user is created in the main PostgreSQL init script
+GRANT SELECT, INSERT, UPDATE ON accounts TO "spiffe-demo-ledger";
+GRANT SELECT, INSERT ON transactions TO "spiffe-demo-ledger";

--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
+	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -139,6 +139,8 @@ github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.11.0 h1:1iurJgmM9G3PA/I+wWYIOw/5SyBtxapeHDcg+AAIFXc=
 github.com/sagikazarmark/locafero v0.11.0/go.mod h1:nVIGvgyzw595SUSUE6tvCp3YYTeHs15MvlmU87WwIik=
+github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
+github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 h1:+jumHNA0Wrelhe64i8F6HNlS8pkoyMv5sreGx2Ry5Rw=
 github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8/go.mod h1:3n1Cwaq1E1/1lhQhtRK2ts/ZwZEhjcQeJQ1RuC6Q/8U=
 github.com/spf13/afero v1.15.0 h1:b/YBCLWAJdFWJTN9cLhiXXcD7mzKn9Dm86dNnfyQw1I=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -80,13 +80,10 @@ type LedgerConfig struct {
 }
 
 // LedgerPostgreSQLConfig contains PostgreSQL configuration for the ledger service.
+// Note: SSL/TLS is handled via SPIFFE X509Source, not manual certificate paths.
 type LedgerPostgreSQLConfig struct {
-	Host        string `mapstructure:"host"`
-	Port        int    `mapstructure:"port"`
-	User        string `mapstructure:"user"`
-	Database    string `mapstructure:"database"`
-	SSLMode     string `mapstructure:"ssl_mode"`
-	SSLCert     string `mapstructure:"ssl_cert"`
-	SSLKey      string `mapstructure:"ssl_key"`
-	SSLRootCert string `mapstructure:"ssl_root_cert"`
+	Host     string `mapstructure:"host"`
+	Port     int    `mapstructure:"port"`
+	User     string `mapstructure:"user"`
+	Database string `mapstructure:"database"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -80,10 +80,10 @@ type LedgerConfig struct {
 }
 
 // LedgerPostgreSQLConfig contains PostgreSQL configuration for the ledger service.
-// Note: SSL/TLS is handled via SPIFFE X509Source, not manual certificate paths.
+// Note: SSL/TLS and username are handled via SPIFFE X509Source.
+// The username is automatically extracted from the SVID certificate's Common Name.
 type LedgerPostgreSQLConfig struct {
 	Host     string `mapstructure:"host"`
 	Port     int    `mapstructure:"port"`
-	User     string `mapstructure:"user"`
 	Database string `mapstructure:"database"`
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	Server   ServerConfig   `mapstructure:"server"`
 	Spiffe   SpiffeConfig   `mapstructure:"spiffe"`
 	Customer CustomerConfig `mapstructure:"customer"`
+	Ledger   LedgerConfig   `mapstructure:"ledger"`
 }
 
 // ServerConfig contains server-related configuration.
@@ -70,4 +71,22 @@ type GCPConfig struct {
 type PostgreSQLConfig struct {
 	Host string `mapstructure:"host"`
 	User string `mapstructure:"user"`
+}
+
+// LedgerConfig contains ledger service specific configuration.
+type LedgerConfig struct {
+	UseMock    bool                    `mapstructure:"use_mock"`
+	PostgreSQL LedgerPostgreSQLConfig `mapstructure:"postgresql"`
+}
+
+// LedgerPostgreSQLConfig contains PostgreSQL configuration for the ledger service.
+type LedgerPostgreSQLConfig struct {
+	Host        string `mapstructure:"host"`
+	Port        int    `mapstructure:"port"`
+	User        string `mapstructure:"user"`
+	Database    string `mapstructure:"database"`
+	SSLMode     string `mapstructure:"ssl_mode"`
+	SSLCert     string `mapstructure:"ssl_cert"`
+	SSLKey      string `mapstructure:"ssl_key"`
+	SSLRootCert string `mapstructure:"ssl_root_cert"`
 }

--- a/pkg/ledger/errors.go
+++ b/pkg/ledger/errors.go
@@ -1,0 +1,42 @@
+/*
+Copyright © 2024 Mattias Gees mattias.gees@venafi.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ledger
+
+import "errors"
+
+var (
+	// ErrAccountNotFound is returned when an account is not found.
+	ErrAccountNotFound = errors.New("account not found")
+
+	// ErrInsufficientFunds is returned when an account has insufficient funds for a transfer.
+	ErrInsufficientFunds = errors.New("insufficient funds")
+
+	// ErrInvalidFromAccount is returned when the from account is invalid.
+	ErrInvalidFromAccount = errors.New("invalid from account")
+
+	// ErrInvalidToAccount is returned when the to account is invalid.
+	ErrInvalidToAccount = errors.New("invalid to account")
+
+	// ErrSameAccount is returned when trying to transfer to the same account.
+	ErrSameAccount = errors.New("cannot transfer to the same account")
+
+	// ErrInvalidAmount is returned when the transfer amount is invalid.
+	ErrInvalidAmount = errors.New("amount must be greater than zero")
+
+	// ErrTransactionNotFound is returned when a transaction is not found.
+	ErrTransactionNotFound = errors.New("transaction not found")
+)

--- a/pkg/ledger/handlers.go
+++ b/pkg/ledger/handlers.go
@@ -1,0 +1,232 @@
+/*
+Copyright © 2024 Mattias Gees mattias.gees@venafi.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package ledger
+
+import (
+	"encoding/json"
+	"errors"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/spiffe/go-spiffe/v2/spiffetls"
+)
+
+// RegisterRoutes registers all HTTP routes for the ledger service.
+func (s *Service) RegisterRoutes(mux *http.ServeMux) {
+	// Account endpoints
+	mux.HandleFunc("GET /api/accounts", s.handleGetAccounts)
+	mux.HandleFunc("GET /api/accounts/{id}", s.handleGetAccount)
+
+	// Transfer endpoint
+	mux.HandleFunc("POST /api/transfers", s.handleCreateTransfer)
+
+	// Transaction endpoints
+	mux.HandleFunc("GET /api/transactions", s.handleGetTransactions)
+	mux.HandleFunc("GET /api/transactions/{id}", s.handleGetTransaction)
+
+	// Health check
+	mux.HandleFunc("GET /health", s.handleHealth)
+}
+
+// APIResponse is the standard response wrapper for all API responses.
+type APIResponse struct {
+	Success bool        `json:"success"`
+	Data    interface{} `json:"data,omitempty"`
+	Error   string      `json:"error,omitempty"`
+}
+
+// writeJSON writes a JSON response with the given status code.
+func writeJSON(w http.ResponseWriter, status int, data interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if err := json.NewEncoder(w).Encode(data); err != nil {
+		log.Printf("Error encoding JSON response: %v", err)
+	}
+}
+
+// writeSuccess writes a successful JSON response.
+func writeSuccess(w http.ResponseWriter, data interface{}) {
+	writeJSON(w, http.StatusOK, APIResponse{
+		Success: true,
+		Data:    data,
+	})
+}
+
+// writeError writes an error JSON response.
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, APIResponse{
+		Success: false,
+		Error:   message,
+	})
+}
+
+// logRequest logs the incoming request with SPIFFE ID if available.
+func (s *Service) logRequest(r *http.Request, action string) {
+	clientID := "unknown"
+	if r.TLS != nil {
+		if id, err := spiffetls.PeerIDFromConnectionState(*r.TLS); err == nil {
+			clientID = id.String()
+		}
+	}
+	log.Printf("[%s] %s %s from %s (SPIFFE: %s)", action, r.Method, r.URL.Path, r.RemoteAddr, clientID)
+}
+
+// handleHealth handles GET /health requests.
+func (s *Service) handleHealth(w http.ResponseWriter, r *http.Request) {
+	writeSuccess(w, map[string]string{"status": "healthy"})
+}
+
+// handleGetAccounts handles GET /api/accounts requests.
+func (s *Service) handleGetAccounts(w http.ResponseWriter, r *http.Request) {
+	s.logRequest(r, "GetAccounts")
+
+	accounts, err := s.store.GetAccounts(r.Context())
+	if err != nil {
+		log.Printf("Error getting accounts: %v", err)
+		writeError(w, http.StatusInternalServerError, "Failed to retrieve accounts")
+		return
+	}
+
+	writeSuccess(w, accounts)
+}
+
+// handleGetAccount handles GET /api/accounts/{id} requests.
+func (s *Service) handleGetAccount(w http.ResponseWriter, r *http.Request) {
+	s.logRequest(r, "GetAccount")
+
+	// Parse the account ID from the URL path
+	idStr := r.PathValue("id")
+	if idStr == "" {
+		writeError(w, http.StatusBadRequest, "Account ID is required")
+		return
+	}
+
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid account ID format")
+		return
+	}
+
+	account, err := s.store.GetAccount(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, ErrAccountNotFound) {
+			writeError(w, http.StatusNotFound, "Account not found")
+			return
+		}
+		log.Printf("Error getting account: %v", err)
+		writeError(w, http.StatusInternalServerError, "Failed to retrieve account")
+		return
+	}
+
+	writeSuccess(w, account)
+}
+
+// handleCreateTransfer handles POST /api/transfers requests.
+func (s *Service) handleCreateTransfer(w http.ResponseWriter, r *http.Request) {
+	s.logRequest(r, "CreateTransfer")
+
+	// Validate content type
+	contentType := r.Header.Get("Content-Type")
+	if !strings.HasPrefix(contentType, "application/json") {
+		writeError(w, http.StatusUnsupportedMediaType, "Content-Type must be application/json")
+		return
+	}
+
+	// Parse request body
+	var req TransferRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+
+	// Create the transfer
+	transaction, err := s.store.CreateTransfer(r.Context(), req)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrAccountNotFound):
+			writeError(w, http.StatusNotFound, "Account not found")
+		case errors.Is(err, ErrInsufficientFunds):
+			writeError(w, http.StatusBadRequest, "Insufficient funds")
+		case errors.Is(err, ErrSameAccount):
+			writeError(w, http.StatusBadRequest, "Cannot transfer to the same account")
+		case errors.Is(err, ErrInvalidAmount):
+			writeError(w, http.StatusBadRequest, "Amount must be greater than zero")
+		case errors.Is(err, ErrInvalidFromAccount):
+			writeError(w, http.StatusBadRequest, "Invalid from account")
+		case errors.Is(err, ErrInvalidToAccount):
+			writeError(w, http.StatusBadRequest, "Invalid to account")
+		default:
+			log.Printf("Error creating transfer: %v", err)
+			writeError(w, http.StatusInternalServerError, "Failed to create transfer")
+		}
+		return
+	}
+
+	log.Printf("Transfer created: %s -> %s, amount: %s",
+		transaction.FromAccount, transaction.ToAccount, transaction.Amount)
+
+	writeJSON(w, http.StatusCreated, APIResponse{
+		Success: true,
+		Data:    transaction,
+	})
+}
+
+// handleGetTransactions handles GET /api/transactions requests.
+func (s *Service) handleGetTransactions(w http.ResponseWriter, r *http.Request) {
+	s.logRequest(r, "GetTransactions")
+
+	transactions, err := s.store.GetTransactions(r.Context())
+	if err != nil {
+		log.Printf("Error getting transactions: %v", err)
+		writeError(w, http.StatusInternalServerError, "Failed to retrieve transactions")
+		return
+	}
+
+	writeSuccess(w, transactions)
+}
+
+// handleGetTransaction handles GET /api/transactions/{id} requests.
+func (s *Service) handleGetTransaction(w http.ResponseWriter, r *http.Request) {
+	s.logRequest(r, "GetTransaction")
+
+	// Parse the transaction ID from the URL path
+	idStr := r.PathValue("id")
+	if idStr == "" {
+		writeError(w, http.StatusBadRequest, "Transaction ID is required")
+		return
+	}
+
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid transaction ID format")
+		return
+	}
+
+	transaction, err := s.store.GetTransaction(r.Context(), id)
+	if err != nil {
+		if errors.Is(err, ErrTransactionNotFound) {
+			writeError(w, http.StatusNotFound, "Transaction not found")
+			return
+		}
+		log.Printf("Error getting transaction: %v", err)
+		writeError(w, http.StatusInternalServerError, "Failed to retrieve transaction")
+		return
+	}
+
+	writeSuccess(w, transaction)
+}

--- a/pkg/ledger/handlers_test.go
+++ b/pkg/ledger/handlers_test.go
@@ -1,0 +1,380 @@
+/*
+Copyright © 2024 Mattias Gees mattias.gees@venafi.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package ledger
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+func newTestService() *Service {
+	return NewService(ServiceConfig{
+		Store: NewMockStore(),
+	})
+}
+
+func TestHandleHealth(t *testing.T) {
+	service := newTestService()
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+
+	service.handleHealth(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	var response APIResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if !response.Success {
+		t.Error("Expected success to be true")
+	}
+}
+
+func TestHandleGetAccounts(t *testing.T) {
+	service := newTestService()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/accounts", nil)
+	w := httptest.NewRecorder()
+
+	service.handleGetAccounts(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	var response APIResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if !response.Success {
+		t.Error("Expected success to be true")
+	}
+
+	// Check that we got accounts
+	accounts, ok := response.Data.([]interface{})
+	if !ok {
+		t.Fatal("Expected Data to be an array")
+	}
+
+	if len(accounts) != 2 {
+		t.Errorf("Expected 2 accounts, got %d", len(accounts))
+	}
+}
+
+func TestHandleGetAccount(t *testing.T) {
+	service := newTestService()
+
+	tests := []struct {
+		name           string
+		id             string
+		expectedStatus int
+		expectSuccess  bool
+	}{
+		{
+			name:           "valid account",
+			id:             "11111111-1111-1111-1111-111111111111",
+			expectedStatus: http.StatusOK,
+			expectSuccess:  true,
+		},
+		{
+			name:           "non-existing account",
+			id:             "99999999-9999-9999-9999-999999999999",
+			expectedStatus: http.StatusNotFound,
+			expectSuccess:  false,
+		},
+		{
+			name:           "invalid UUID format",
+			id:             "invalid-uuid",
+			expectedStatus: http.StatusBadRequest,
+			expectSuccess:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/accounts/"+tt.id, nil)
+			req.SetPathValue("id", tt.id)
+			w := httptest.NewRecorder()
+
+			service.handleGetAccount(w, req)
+
+			if w.Code != tt.expectedStatus {
+				t.Errorf("Expected status %d, got %d", tt.expectedStatus, w.Code)
+			}
+
+			var response APIResponse
+			if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+				t.Fatalf("Failed to decode response: %v", err)
+			}
+
+			if response.Success != tt.expectSuccess {
+				t.Errorf("Expected success=%v, got %v", tt.expectSuccess, response.Success)
+			}
+		})
+	}
+}
+
+func TestHandleCreateTransfer(t *testing.T) {
+	checkingID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	savingsID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+
+	tests := []struct {
+		name           string
+		request        TransferRequest
+		contentType    string
+		expectedStatus int
+		expectSuccess  bool
+	}{
+		{
+			name: "valid transfer",
+			request: TransferRequest{
+				FromAccount: checkingID,
+				ToAccount:   savingsID,
+				Amount:      decimal.NewFromFloat(100.00),
+				Description: "Test transfer",
+			},
+			contentType:    "application/json",
+			expectedStatus: http.StatusCreated,
+			expectSuccess:  true,
+		},
+		{
+			name: "insufficient funds",
+			request: TransferRequest{
+				FromAccount: checkingID,
+				ToAccount:   savingsID,
+				Amount:      decimal.NewFromFloat(10000.00),
+				Description: "Too much",
+			},
+			contentType:    "application/json",
+			expectedStatus: http.StatusBadRequest,
+			expectSuccess:  false,
+		},
+		{
+			name: "same account",
+			request: TransferRequest{
+				FromAccount: checkingID,
+				ToAccount:   checkingID,
+				Amount:      decimal.NewFromFloat(100.00),
+			},
+			contentType:    "application/json",
+			expectedStatus: http.StatusBadRequest,
+			expectSuccess:  false,
+		},
+		{
+			name: "zero amount",
+			request: TransferRequest{
+				FromAccount: checkingID,
+				ToAccount:   savingsID,
+				Amount:      decimal.Zero,
+			},
+			contentType:    "application/json",
+			expectedStatus: http.StatusBadRequest,
+			expectSuccess:  false,
+		},
+		{
+			name: "non-existing from account",
+			request: TransferRequest{
+				FromAccount: uuid.MustParse("99999999-9999-9999-9999-999999999999"),
+				ToAccount:   savingsID,
+				Amount:      decimal.NewFromFloat(100.00),
+			},
+			contentType:    "application/json",
+			expectedStatus: http.StatusNotFound,
+			expectSuccess:  false,
+		},
+		{
+			name: "wrong content type",
+			request: TransferRequest{
+				FromAccount: checkingID,
+				ToAccount:   savingsID,
+				Amount:      decimal.NewFromFloat(100.00),
+			},
+			contentType:    "text/plain",
+			expectedStatus: http.StatusUnsupportedMediaType,
+			expectSuccess:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a fresh service for each test
+			service := newTestService()
+
+			body, _ := json.Marshal(tt.request)
+			req := httptest.NewRequest(http.MethodPost, "/api/transfers", bytes.NewReader(body))
+			req.Header.Set("Content-Type", tt.contentType)
+			w := httptest.NewRecorder()
+
+			service.handleCreateTransfer(w, req)
+
+			if w.Code != tt.expectedStatus {
+				t.Errorf("Expected status %d, got %d", tt.expectedStatus, w.Code)
+			}
+
+			var response APIResponse
+			if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+				t.Fatalf("Failed to decode response: %v", err)
+			}
+
+			if response.Success != tt.expectSuccess {
+				t.Errorf("Expected success=%v, got %v", tt.expectSuccess, response.Success)
+			}
+		})
+	}
+}
+
+func TestHandleGetTransactions(t *testing.T) {
+	service := newTestService()
+
+	// Initially no transactions
+	req := httptest.NewRequest(http.MethodGet, "/api/transactions", nil)
+	w := httptest.NewRecorder()
+
+	service.handleGetTransactions(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("Expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	var response APIResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if !response.Success {
+		t.Error("Expected success to be true")
+	}
+}
+
+func TestHandleGetTransaction(t *testing.T) {
+	service := newTestService()
+
+	// First create a transaction
+	checkingID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	savingsID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+
+	body, _ := json.Marshal(TransferRequest{
+		FromAccount: checkingID,
+		ToAccount:   savingsID,
+		Amount:      decimal.NewFromFloat(100.00),
+	})
+	createReq := httptest.NewRequest(http.MethodPost, "/api/transfers", bytes.NewReader(body))
+	createReq.Header.Set("Content-Type", "application/json")
+	createW := httptest.NewRecorder()
+
+	service.handleCreateTransfer(createW, createReq)
+
+	if createW.Code != http.StatusCreated {
+		t.Fatalf("Failed to create transfer: %d", createW.Code)
+	}
+
+	var createResponse APIResponse
+	if err := json.NewDecoder(createW.Body).Decode(&createResponse); err != nil {
+		t.Fatalf("Failed to decode create response: %v", err)
+	}
+
+	// Extract transaction ID
+	transactionData, ok := createResponse.Data.(map[string]interface{})
+	if !ok {
+		t.Fatal("Expected Data to be a map")
+	}
+	transactionID := transactionData["id"].(string)
+
+	// Test getting the transaction
+	tests := []struct {
+		name           string
+		id             string
+		expectedStatus int
+		expectSuccess  bool
+	}{
+		{
+			name:           "existing transaction",
+			id:             transactionID,
+			expectedStatus: http.StatusOK,
+			expectSuccess:  true,
+		},
+		{
+			name:           "non-existing transaction",
+			id:             "99999999-9999-9999-9999-999999999999",
+			expectedStatus: http.StatusNotFound,
+			expectSuccess:  false,
+		},
+		{
+			name:           "invalid UUID format",
+			id:             "invalid-uuid",
+			expectedStatus: http.StatusBadRequest,
+			expectSuccess:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/transactions/"+tt.id, nil)
+			req.SetPathValue("id", tt.id)
+			w := httptest.NewRecorder()
+
+			service.handleGetTransaction(w, req)
+
+			if w.Code != tt.expectedStatus {
+				t.Errorf("Expected status %d, got %d", tt.expectedStatus, w.Code)
+			}
+
+			var response APIResponse
+			if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+				t.Fatalf("Failed to decode response: %v", err)
+			}
+
+			if response.Success != tt.expectSuccess {
+				t.Errorf("Expected success=%v, got %v", tt.expectSuccess, response.Success)
+			}
+		})
+	}
+}
+
+func TestHandleCreateTransfer_InvalidJSON(t *testing.T) {
+	service := newTestService()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/transfers", bytes.NewReader([]byte("invalid json")))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	service.handleCreateTransfer(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
+	}
+
+	var response APIResponse
+	if err := json.NewDecoder(w.Body).Decode(&response); err != nil {
+		t.Fatalf("Failed to decode response: %v", err)
+	}
+
+	if response.Success {
+		t.Error("Expected success to be false")
+	}
+}

--- a/pkg/ledger/mock_store.go
+++ b/pkg/ledger/mock_store.go
@@ -1,0 +1,175 @@
+/*
+Copyright © 2024 Mattias Gees mattias.gees@venafi.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ledger
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+// MockStore is an in-memory implementation of the Store interface for testing.
+type MockStore struct {
+	mu           sync.RWMutex
+	accounts     map[uuid.UUID]*Account
+	transactions []Transaction
+}
+
+// NewMockStore creates a new MockStore with default test accounts.
+func NewMockStore() *MockStore {
+	store := &MockStore{
+		accounts:     make(map[uuid.UUID]*Account),
+		transactions: make([]Transaction, 0),
+	}
+
+	// Add default test accounts
+	checkingID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	savingsID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+
+	store.accounts[checkingID] = &Account{
+		ID:        checkingID,
+		Name:      "Checking",
+		Balance:   decimal.NewFromFloat(5000.00),
+		CreatedAt: time.Now().UTC(),
+	}
+
+	store.accounts[savingsID] = &Account{
+		ID:        savingsID,
+		Name:      "Savings",
+		Balance:   decimal.NewFromFloat(5000.00),
+		CreatedAt: time.Now().UTC(),
+	}
+
+	return store
+}
+
+// GetAccounts returns all accounts.
+func (s *MockStore) GetAccounts(ctx context.Context) ([]Account, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	accounts := make([]Account, 0, len(s.accounts))
+	for _, a := range s.accounts {
+		accounts = append(accounts, *a)
+	}
+	return accounts, nil
+}
+
+// GetAccount returns a single account by ID.
+func (s *MockStore) GetAccount(ctx context.Context, id uuid.UUID) (*Account, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	account, ok := s.accounts[id]
+	if !ok {
+		return nil, ErrAccountNotFound
+	}
+	// Return a copy to prevent external modification
+	accountCopy := *account
+	return &accountCopy, nil
+}
+
+// GetTransactions returns all transactions, ordered by creation time (newest first).
+func (s *MockStore) GetTransactions(ctx context.Context) ([]Transaction, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	// Return a copy of the transactions slice
+	transactions := make([]Transaction, len(s.transactions))
+	copy(transactions, s.transactions)
+	return transactions, nil
+}
+
+// GetTransaction returns a single transaction by ID.
+func (s *MockStore) GetTransaction(ctx context.Context, id uuid.UUID) (*Transaction, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for _, t := range s.transactions {
+		if t.ID == id {
+			return &t, nil
+		}
+	}
+	return nil, ErrTransactionNotFound
+}
+
+// CreateTransfer creates a new transfer between accounts.
+func (s *MockStore) CreateTransfer(ctx context.Context, req TransferRequest) (*Transaction, error) {
+	// Validate the request
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Check from account exists and has sufficient funds
+	fromAccount, ok := s.accounts[req.FromAccount]
+	if !ok {
+		return nil, ErrAccountNotFound
+	}
+
+	if fromAccount.Balance.LessThan(req.Amount) {
+		return nil, ErrInsufficientFunds
+	}
+
+	// Check to account exists
+	toAccount, ok := s.accounts[req.ToAccount]
+	if !ok {
+		return nil, ErrAccountNotFound
+	}
+
+	// Perform the transfer
+	fromAccount.Balance = fromAccount.Balance.Sub(req.Amount)
+	toAccount.Balance = toAccount.Balance.Add(req.Amount)
+
+	// Create transaction record
+	transaction := Transaction{
+		ID:          uuid.New(),
+		FromAccount: req.FromAccount,
+		ToAccount:   req.ToAccount,
+		Amount:      req.Amount,
+		Description: req.Description,
+		CreatedAt:   time.Now().UTC(),
+	}
+
+	// Prepend to transactions list (newest first)
+	s.transactions = append([]Transaction{transaction}, s.transactions...)
+
+	return &transaction, nil
+}
+
+// Close closes the store (no-op for mock).
+func (s *MockStore) Close() error {
+	return nil
+}
+
+// Reset resets the mock store to its initial state (useful for tests).
+func (s *MockStore) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	checkingID := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	savingsID := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+
+	s.accounts[checkingID].Balance = decimal.NewFromFloat(5000.00)
+	s.accounts[savingsID].Balance = decimal.NewFromFloat(5000.00)
+	s.transactions = make([]Transaction, 0)
+}

--- a/pkg/ledger/models.go
+++ b/pkg/ledger/models.go
@@ -1,0 +1,89 @@
+/*
+Copyright © 2024 Mattias Gees mattias.gees@venafi.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package ledger provides the TrustBank ledger service for managing accounts and transactions.
+package ledger
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+// Account represents a bank account in the TrustBank system.
+type Account struct {
+	ID        uuid.UUID       `json:"id"`
+	Name      string          `json:"name"`
+	Balance   decimal.Decimal `json:"balance"`
+	CreatedAt time.Time       `json:"created_at"`
+}
+
+// Transaction represents a money transfer between accounts.
+type Transaction struct {
+	ID          uuid.UUID       `json:"id"`
+	FromAccount uuid.UUID       `json:"from_account"`
+	ToAccount   uuid.UUID       `json:"to_account"`
+	Amount      decimal.Decimal `json:"amount"`
+	Description string          `json:"description,omitempty"`
+	CreatedAt   time.Time       `json:"created_at"`
+}
+
+// TransferRequest represents a request to transfer money between accounts.
+type TransferRequest struct {
+	FromAccount uuid.UUID       `json:"from_account"`
+	ToAccount   uuid.UUID       `json:"to_account"`
+	Amount      decimal.Decimal `json:"amount"`
+	Description string          `json:"description,omitempty"`
+}
+
+// Validate checks if the transfer request is valid.
+func (t *TransferRequest) Validate() error {
+	if t.FromAccount == uuid.Nil {
+		return ErrInvalidFromAccount
+	}
+	if t.ToAccount == uuid.Nil {
+		return ErrInvalidToAccount
+	}
+	if t.FromAccount == t.ToAccount {
+		return ErrSameAccount
+	}
+	if t.Amount.LessThanOrEqual(decimal.Zero) {
+		return ErrInvalidAmount
+	}
+	return nil
+}
+
+// AccountsResponse represents the response for listing accounts.
+type AccountsResponse struct {
+	Accounts []Account `json:"accounts"`
+}
+
+// TransactionsResponse represents the response for listing transactions.
+type TransactionsResponse struct {
+	Transactions []Transaction `json:"transactions"`
+}
+
+// TransactionResponse represents the response for a single transaction.
+type TransactionResponse struct {
+	Transaction Transaction `json:"transaction"`
+}
+
+// ErrorResponse represents an error response from the API.
+type ErrorResponse struct {
+	Error   string `json:"error"`
+	Message string `json:"message,omitempty"`
+}

--- a/pkg/ledger/models_test.go
+++ b/pkg/ledger/models_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright © 2024 Mattias Gees mattias.gees@venafi.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ledger
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+func TestTransferRequest_Validate(t *testing.T) {
+	validFromAccount := uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	validToAccount := uuid.MustParse("22222222-2222-2222-2222-222222222222")
+	validAmount := decimal.NewFromFloat(100.00)
+
+	tests := []struct {
+		name    string
+		request TransferRequest
+		wantErr error
+	}{
+		{
+			name: "valid request",
+			request: TransferRequest{
+				FromAccount: validFromAccount,
+				ToAccount:   validToAccount,
+				Amount:      validAmount,
+				Description: "Test transfer",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "valid request without description",
+			request: TransferRequest{
+				FromAccount: validFromAccount,
+				ToAccount:   validToAccount,
+				Amount:      validAmount,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "nil from account",
+			request: TransferRequest{
+				FromAccount: uuid.Nil,
+				ToAccount:   validToAccount,
+				Amount:      validAmount,
+			},
+			wantErr: ErrInvalidFromAccount,
+		},
+		{
+			name: "nil to account",
+			request: TransferRequest{
+				FromAccount: validFromAccount,
+				ToAccount:   uuid.Nil,
+				Amount:      validAmount,
+			},
+			wantErr: ErrInvalidToAccount,
+		},
+		{
+			name: "same account",
+			request: TransferRequest{
+				FromAccount: validFromAccount,
+				ToAccount:   validFromAccount,
+				Amount:      validAmount,
+			},
+			wantErr: ErrSameAccount,
+		},
+		{
+			name: "zero amount",
+			request: TransferRequest{
+				FromAccount: validFromAccount,
+				ToAccount:   validToAccount,
+				Amount:      decimal.Zero,
+			},
+			wantErr: ErrInvalidAmount,
+		},
+		{
+			name: "negative amount",
+			request: TransferRequest{
+				FromAccount: validFromAccount,
+				ToAccount:   validToAccount,
+				Amount:      decimal.NewFromFloat(-100.00),
+			},
+			wantErr: ErrInvalidAmount,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.request.Validate()
+			if err != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestAccount_JSONTags(t *testing.T) {
+	// This test ensures the JSON tags are correctly set by marshaling/unmarshaling
+	// For now, just verify the struct can be created
+	account := Account{
+		ID:      uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+		Name:    "Test Account",
+		Balance: decimal.NewFromFloat(1000.00),
+	}
+
+	if account.Name != "Test Account" {
+		t.Errorf("Expected name 'Test Account', got '%s'", account.Name)
+	}
+
+	if !account.Balance.Equal(decimal.NewFromFloat(1000.00)) {
+		t.Errorf("Expected balance 1000.00, got %s", account.Balance.String())
+	}
+}
+
+func TestTransaction_JSONTags(t *testing.T) {
+	// Verify the struct can be created
+	transaction := Transaction{
+		ID:          uuid.MustParse("33333333-3333-3333-3333-333333333333"),
+		FromAccount: uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+		ToAccount:   uuid.MustParse("22222222-2222-2222-2222-222222222222"),
+		Amount:      decimal.NewFromFloat(100.00),
+		Description: "Test transaction",
+	}
+
+	if !transaction.Amount.Equal(decimal.NewFromFloat(100.00)) {
+		t.Errorf("Expected amount 100.00, got %s", transaction.Amount.String())
+	}
+
+	if transaction.Description != "Test transaction" {
+		t.Errorf("Expected description 'Test transaction', got '%s'", transaction.Description)
+	}
+}

--- a/pkg/ledger/postgres.go
+++ b/pkg/ledger/postgres.go
@@ -40,7 +40,6 @@ type PostgresStore struct {
 type PostgresConfig struct {
 	Host     string
 	Port     int
-	User     string
 	Database string
 }
 
@@ -51,10 +50,22 @@ type PostgresConfig struct {
 // Instead of using static certificates or passwords, the ledger service uses its
 // SPIFFE identity (X.509-SVID) to authenticate to PostgreSQL. The X509Source
 // automatically obtains and rotates certificates from the SPIFFE Workload API.
-// PostgreSQL is configured to trust the SPIFFE CA and map the SPIFFE ID's CN
-// (Common Name) to a database user.
+// PostgreSQL is configured to trust the SPIFFE CA and map the certificate's
+// Common Name (CN) to a database user - no separate username configuration needed.
 func NewPostgresStore(ctx context.Context, cfg PostgresConfig, source *workloadapi.X509Source) (*PostgresStore, error) {
-	connString := buildConnectionString(cfg)
+	// Extract username from the SVID's Common Name
+	svid, err := source.GetX509SVID()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get X509-SVID: %w", err)
+	}
+
+	// The CN from the SPIFFE certificate is used as the PostgreSQL username
+	user := svid.Certificates[0].Subject.CommonName
+	if user == "" {
+		return nil, fmt.Errorf("SVID certificate has no Common Name for database user")
+	}
+
+	connString := buildConnectionString(cfg, user)
 
 	poolConfig, err := pgxpool.ParseConfig(connString)
 	if err != nil {
@@ -89,7 +100,8 @@ func NewPostgresStore(ctx context.Context, cfg PostgresConfig, source *workloada
 }
 
 // buildConnectionString builds a PostgreSQL connection string from the config.
-func buildConnectionString(cfg PostgresConfig) string {
+// The user parameter is extracted from the SPIFFE SVID's Common Name.
+func buildConnectionString(cfg PostgresConfig, user string) string {
 	port := cfg.Port
 	if port == 0 {
 		port = 5432
@@ -103,7 +115,7 @@ func buildConnectionString(cfg PostgresConfig) string {
 	// Always use 'require' SSL mode since we're using SPIFFE mTLS
 	return fmt.Sprintf(
 		"host=%s port=%d user=%s dbname=%s sslmode=require",
-		cfg.Host, port, cfg.User, database,
+		cfg.Host, port, user, database,
 	)
 }
 

--- a/pkg/ledger/postgres.go
+++ b/pkg/ledger/postgres.go
@@ -1,0 +1,369 @@
+/*
+Copyright © 2024 Mattias Gees mattias.gees@venafi.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ledger
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/shopspring/decimal"
+)
+
+// PostgresStore implements the Store interface using PostgreSQL.
+type PostgresStore struct {
+	pool *pgxpool.Pool
+}
+
+// PostgresConfig contains the configuration for connecting to PostgreSQL.
+type PostgresConfig struct {
+	Host     string
+	Port     int
+	User     string
+	Database string
+	// SSLMode specifies the SSL mode (disable, require, verify-ca, verify-full)
+	SSLMode string
+	// SSLCert is the path to the client certificate file (for X.509 auth)
+	SSLCert string
+	// SSLKey is the path to the client private key file (for X.509 auth)
+	SSLKey string
+	// SSLRootCert is the path to the root CA certificate file
+	SSLRootCert string
+}
+
+// NewPostgresStore creates a new PostgresStore with the given configuration.
+func NewPostgresStore(ctx context.Context, cfg PostgresConfig) (*PostgresStore, error) {
+	connString := buildConnectionString(cfg)
+
+	poolConfig, err := pgxpool.ParseConfig(connString)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse connection string: %w", err)
+	}
+
+	// Configure TLS if SSL certificates are provided
+	if cfg.SSLCert != "" && cfg.SSLKey != "" {
+		tlsConfig, err := buildTLSConfig(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to build TLS config: %w", err)
+		}
+		poolConfig.ConnConfig.TLSConfig = tlsConfig
+	}
+
+	// Set pool configuration
+	poolConfig.MaxConns = 10
+	poolConfig.MinConns = 2
+	poolConfig.MaxConnLifetime = time.Hour
+	poolConfig.MaxConnIdleTime = 30 * time.Minute
+
+	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create connection pool: %w", err)
+	}
+
+	// Test the connection
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		return nil, fmt.Errorf("failed to ping database: %w", err)
+	}
+
+	return &PostgresStore{pool: pool}, nil
+}
+
+// buildConnectionString builds a PostgreSQL connection string from the config.
+func buildConnectionString(cfg PostgresConfig) string {
+	port := cfg.Port
+	if port == 0 {
+		port = 5432
+	}
+
+	database := cfg.Database
+	if database == "" {
+		database = "trustbank"
+	}
+
+	sslMode := cfg.SSLMode
+	if sslMode == "" {
+		sslMode = "disable"
+	}
+
+	return fmt.Sprintf(
+		"host=%s port=%d user=%s dbname=%s sslmode=%s",
+		cfg.Host, port, cfg.User, database, sslMode,
+	)
+}
+
+// buildTLSConfig builds a TLS configuration for X.509 certificate authentication.
+func buildTLSConfig(cfg PostgresConfig) (*tls.Config, error) {
+	cert, err := tls.LoadX509KeyPair(cfg.SSLCert, cfg.SSLKey)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load client certificate: %w", err)
+	}
+
+	tlsConfig := &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		MinVersion:   tls.VersionTLS12,
+	}
+
+	if cfg.SSLRootCert != "" {
+		rootCert, err := os.ReadFile(cfg.SSLRootCert)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read root certificate: %w", err)
+		}
+
+		rootCertPool := x509.NewCertPool()
+		if !rootCertPool.AppendCertsFromPEM(rootCert) {
+			return nil, fmt.Errorf("failed to append root certificate")
+		}
+		tlsConfig.RootCAs = rootCertPool
+	}
+
+	return tlsConfig, nil
+}
+
+// Close closes the database connection pool.
+func (s *PostgresStore) Close() error {
+	s.pool.Close()
+	return nil
+}
+
+// GetAccounts returns all accounts.
+func (s *PostgresStore) GetAccounts(ctx context.Context) ([]Account, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, name, balance, created_at
+		FROM accounts
+		ORDER BY name
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query accounts: %w", err)
+	}
+	defer rows.Close()
+
+	var accounts []Account
+	for rows.Next() {
+		var a Account
+		var balanceStr string
+		if err := rows.Scan(&a.ID, &a.Name, &balanceStr, &a.CreatedAt); err != nil {
+			return nil, fmt.Errorf("failed to scan account: %w", err)
+		}
+		a.Balance, err = decimal.NewFromString(balanceStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse balance: %w", err)
+		}
+		accounts = append(accounts, a)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating accounts: %w", err)
+	}
+
+	return accounts, nil
+}
+
+// GetAccount returns a single account by ID.
+func (s *PostgresStore) GetAccount(ctx context.Context, id uuid.UUID) (*Account, error) {
+	var a Account
+	var balanceStr string
+
+	err := s.pool.QueryRow(ctx, `
+		SELECT id, name, balance, created_at
+		FROM accounts
+		WHERE id = $1
+	`, id).Scan(&a.ID, &a.Name, &balanceStr, &a.CreatedAt)
+
+	if err == pgx.ErrNoRows {
+		return nil, ErrAccountNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to query account: %w", err)
+	}
+
+	a.Balance, err = decimal.NewFromString(balanceStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse balance: %w", err)
+	}
+
+	return &a, nil
+}
+
+// GetTransactions returns all transactions, ordered by creation time (newest first).
+func (s *PostgresStore) GetTransactions(ctx context.Context) ([]Transaction, error) {
+	rows, err := s.pool.Query(ctx, `
+		SELECT id, from_account, to_account, amount, description, created_at
+		FROM transactions
+		ORDER BY created_at DESC
+		LIMIT 100
+	`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query transactions: %w", err)
+	}
+	defer rows.Close()
+
+	var transactions []Transaction
+	for rows.Next() {
+		var t Transaction
+		var amountStr string
+		var description *string
+		if err := rows.Scan(&t.ID, &t.FromAccount, &t.ToAccount, &amountStr, &description, &t.CreatedAt); err != nil {
+			return nil, fmt.Errorf("failed to scan transaction: %w", err)
+		}
+		t.Amount, err = decimal.NewFromString(amountStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse amount: %w", err)
+		}
+		if description != nil {
+			t.Description = *description
+		}
+		transactions = append(transactions, t)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating transactions: %w", err)
+	}
+
+	return transactions, nil
+}
+
+// GetTransaction returns a single transaction by ID.
+func (s *PostgresStore) GetTransaction(ctx context.Context, id uuid.UUID) (*Transaction, error) {
+	var t Transaction
+	var amountStr string
+	var description *string
+
+	err := s.pool.QueryRow(ctx, `
+		SELECT id, from_account, to_account, amount, description, created_at
+		FROM transactions
+		WHERE id = $1
+	`, id).Scan(&t.ID, &t.FromAccount, &t.ToAccount, &amountStr, &description, &t.CreatedAt)
+
+	if err == pgx.ErrNoRows {
+		return nil, ErrTransactionNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to query transaction: %w", err)
+	}
+
+	t.Amount, err = decimal.NewFromString(amountStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse amount: %w", err)
+	}
+	if description != nil {
+		t.Description = *description
+	}
+
+	return &t, nil
+}
+
+// CreateTransfer creates a new transfer between accounts.
+// This operation is atomic - either both accounts are updated or neither is.
+func (s *PostgresStore) CreateTransfer(ctx context.Context, req TransferRequest) (*Transaction, error) {
+	// Validate the request
+	if err := req.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Start a transaction
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback(ctx)
+
+	// Lock and check the from account
+	var fromBalance string
+	err = tx.QueryRow(ctx, `
+		SELECT balance FROM accounts WHERE id = $1 FOR UPDATE
+	`, req.FromAccount).Scan(&fromBalance)
+	if err == pgx.ErrNoRows {
+		return nil, ErrAccountNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to lock from account: %w", err)
+	}
+
+	fromBalanceDec, err := decimal.NewFromString(fromBalance)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse from balance: %w", err)
+	}
+
+	if fromBalanceDec.LessThan(req.Amount) {
+		return nil, ErrInsufficientFunds
+	}
+
+	// Lock and check the to account exists
+	var toBalance string
+	err = tx.QueryRow(ctx, `
+		SELECT balance FROM accounts WHERE id = $1 FOR UPDATE
+	`, req.ToAccount).Scan(&toBalance)
+	if err == pgx.ErrNoRows {
+		return nil, ErrAccountNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to lock to account: %w", err)
+	}
+
+	// Deduct from the from account
+	_, err = tx.Exec(ctx, `
+		UPDATE accounts SET balance = balance - $1 WHERE id = $2
+	`, req.Amount.String(), req.FromAccount)
+	if err != nil {
+		return nil, fmt.Errorf("failed to deduct from account: %w", err)
+	}
+
+	// Add to the to account
+	_, err = tx.Exec(ctx, `
+		UPDATE accounts SET balance = balance + $1 WHERE id = $2
+	`, req.Amount.String(), req.ToAccount)
+	if err != nil {
+		return nil, fmt.Errorf("failed to add to account: %w", err)
+	}
+
+	// Create the transaction record
+	transaction := Transaction{
+		ID:          uuid.New(),
+		FromAccount: req.FromAccount,
+		ToAccount:   req.ToAccount,
+		Amount:      req.Amount,
+		Description: req.Description,
+		CreatedAt:   time.Now().UTC(),
+	}
+
+	var descPtr *string
+	if req.Description != "" {
+		descPtr = &req.Description
+	}
+
+	_, err = tx.Exec(ctx, `
+		INSERT INTO transactions (id, from_account, to_account, amount, description, created_at)
+		VALUES ($1, $2, $3, $4, $5, $6)
+	`, transaction.ID, transaction.FromAccount, transaction.ToAccount, transaction.Amount.String(), descPtr, transaction.CreatedAt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to insert transaction: %w", err)
+	}
+
+	// Commit the transaction
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	return &transaction, nil
+}

--- a/pkg/ledger/postgres.go
+++ b/pkg/ledger/postgres.go
@@ -21,13 +21,14 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/shopspring/decimal"
+	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
 )
 
 // PostgresStore implements the Store interface using PostgreSQL.
@@ -41,18 +42,18 @@ type PostgresConfig struct {
 	Port     int
 	User     string
 	Database string
-	// SSLMode specifies the SSL mode (disable, require, verify-ca, verify-full)
-	SSLMode string
-	// SSLCert is the path to the client certificate file (for X.509 auth)
-	SSLCert string
-	// SSLKey is the path to the client private key file (for X.509 auth)
-	SSLKey string
-	// SSLRootCert is the path to the root CA certificate file
-	SSLRootCert string
 }
 
 // NewPostgresStore creates a new PostgresStore with the given configuration.
-func NewPostgresStore(ctx context.Context, cfg PostgresConfig) (*PostgresStore, error) {
+// It requires a SPIFFE X509Source for mTLS authentication to PostgreSQL.
+//
+// SPIFFE CONCEPT: Database Authentication with X.509-SVIDs
+// Instead of using static certificates or passwords, the ledger service uses its
+// SPIFFE identity (X.509-SVID) to authenticate to PostgreSQL. The X509Source
+// automatically obtains and rotates certificates from the SPIFFE Workload API.
+// PostgreSQL is configured to trust the SPIFFE CA and map the SPIFFE ID's CN
+// (Common Name) to a database user.
+func NewPostgresStore(ctx context.Context, cfg PostgresConfig, source *workloadapi.X509Source) (*PostgresStore, error) {
 	connString := buildConnectionString(cfg)
 
 	poolConfig, err := pgxpool.ParseConfig(connString)
@@ -60,14 +61,12 @@ func NewPostgresStore(ctx context.Context, cfg PostgresConfig) (*PostgresStore, 
 		return nil, fmt.Errorf("failed to parse connection string: %w", err)
 	}
 
-	// Configure TLS if SSL certificates are provided
-	if cfg.SSLCert != "" && cfg.SSLKey != "" {
-		tlsConfig, err := buildTLSConfig(cfg)
-		if err != nil {
-			return nil, fmt.Errorf("failed to build TLS config: %w", err)
-		}
-		poolConfig.ConnConfig.TLSConfig = tlsConfig
+	// Configure TLS using SPIFFE X509Source
+	tlsConfig, err := buildSPIFFETLSConfig(source)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build SPIFFE TLS config: %w", err)
 	}
+	poolConfig.ConnConfig.TLSConfig = tlsConfig
 
 	// Set pool configuration
 	poolConfig.MaxConns = 10
@@ -101,43 +100,67 @@ func buildConnectionString(cfg PostgresConfig) string {
 		database = "trustbank"
 	}
 
-	sslMode := cfg.SSLMode
-	if sslMode == "" {
-		sslMode = "disable"
-	}
-
+	// Always use 'require' SSL mode since we're using SPIFFE mTLS
 	return fmt.Sprintf(
-		"host=%s port=%d user=%s dbname=%s sslmode=%s",
-		cfg.Host, port, cfg.User, database, sslMode,
+		"host=%s port=%d user=%s dbname=%s sslmode=require",
+		cfg.Host, port, cfg.User, database,
 	)
 }
 
-// buildTLSConfig builds a TLS configuration for X.509 certificate authentication.
-func buildTLSConfig(cfg PostgresConfig) (*tls.Config, error) {
-	cert, err := tls.LoadX509KeyPair(cfg.SSLCert, cfg.SSLKey)
+// buildSPIFFETLSConfig builds a TLS configuration using SPIFFE X509Source.
+//
+// SPIFFE CONCEPT: Dynamic Certificate Configuration
+// The TLS config uses GetClientCertificate callback which is called on each
+// new connection. This ensures that if SPIRE rotates the certificate, the new
+// certificate is automatically used for subsequent connections without any
+// application restart or manual intervention.
+func buildSPIFFETLSConfig(source *workloadapi.X509Source) (*tls.Config, error) {
+	svid, err := source.GetX509SVID()
 	if err != nil {
-		return nil, fmt.Errorf("failed to load client certificate: %w", err)
+		return nil, fmt.Errorf("failed to get X509-SVID: %w", err)
+	}
+
+	bundle, err := source.GetX509BundleForTrustDomain(svid.ID.TrustDomain())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get X509 bundle: %w", err)
+	}
+
+	// Convert the X.509 bundle authorities to a cert pool
+	rootCAs, err := x509CertPoolFromBundle(bundle)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create cert pool: %w", err)
 	}
 
 	tlsConfig := &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		MinVersion:   tls.VersionTLS12,
-	}
-
-	if cfg.SSLRootCert != "" {
-		rootCert, err := os.ReadFile(cfg.SSLRootCert)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read root certificate: %w", err)
-		}
-
-		rootCertPool := x509.NewCertPool()
-		if !rootCertPool.AppendCertsFromPEM(rootCert) {
-			return nil, fmt.Errorf("failed to append root certificate")
-		}
-		tlsConfig.RootCAs = rootCertPool
+		// GetClientCertificate is called on each connection, ensuring fresh certs
+		GetClientCertificate: func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			svid, err := source.GetX509SVID()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get X509-SVID: %w", err)
+			}
+			tlsCert := &tls.Certificate{
+				Certificate: make([][]byte, len(svid.Certificates)),
+				PrivateKey:  svid.PrivateKey,
+			}
+			for i, cert := range svid.Certificates {
+				tlsCert.Certificate[i] = cert.Raw
+			}
+			return tlsCert, nil
+		},
+		RootCAs:    rootCAs,
+		MinVersion: tls.VersionTLS12,
 	}
 
 	return tlsConfig, nil
+}
+
+// x509CertPoolFromBundle creates an x509.CertPool from a SPIFFE X509Bundle.
+func x509CertPoolFromBundle(bundle *x509bundle.Bundle) (*x509.CertPool, error) {
+	pool := x509.NewCertPool()
+	for _, cert := range bundle.X509Authorities() {
+		pool.AddCert(cert)
+	}
+	return pool, nil
 }
 
 // Close closes the database connection pool.

--- a/pkg/ledger/service.go
+++ b/pkg/ledger/service.go
@@ -1,0 +1,126 @@
+/*
+Copyright © 2024 Mattias Gees mattias.gees@venafi.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package ledger
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
+	"github.com/spiffe/go-spiffe/v2/workloadapi"
+)
+
+// Service represents the ledger service with its dependencies.
+type Service struct {
+	store         Store
+	serverAddress string
+	spiffeAuthz   string
+}
+
+// ServiceConfig contains the configuration for the ledger service.
+type ServiceConfig struct {
+	// ServerAddress is the address to bind the server to (e.g., "0.0.0.0:8080")
+	ServerAddress string
+	// SpiffeAuthz is the authorized SPIFFE ID that can connect to this service
+	SpiffeAuthz string
+	// Store is the data store implementation
+	Store Store
+}
+
+// NewService creates a new ledger service with the given configuration.
+func NewService(cfg ServiceConfig) *Service {
+	return &Service{
+		store:         cfg.Store,
+		serverAddress: cfg.ServerAddress,
+		spiffeAuthz:   cfg.SpiffeAuthz,
+	}
+}
+
+// Run starts the ledger service with SPIFFE mTLS authentication.
+//
+// SPIFFE CONCEPT: SPIFFE-Native Banking Service
+// This ledger service demonstrates how to build a secure banking API that natively
+// understands SPIFFE. The service uses the SPIFFE Workload API to automatically
+// obtain and rotate X.509 certificates (SVIDs). Only clients with the authorized
+// SPIFFE ID can connect - implementing zero-trust identity-based access control.
+func (s *Service) Run(ctx context.Context) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Set up HTTP routes
+	mux := http.NewServeMux()
+	s.RegisterRoutes(mux)
+
+	// SPIFFE CONCEPT: Server-Side X509Source
+	// The X509Source connects to the SPIFFE Workload API (typically via a Unix socket)
+	// to obtain the server's X.509-SVID (SPIFFE Verifiable Identity Document).
+	// This certificate will be presented to clients during TLS handshake.
+	// Certificate rotation is automatic - SPIRE handles renewal before expiry.
+	source, err := workloadapi.NewX509Source(ctx)
+	if err != nil {
+		return fmt.Errorf("unable to create X509Source: %w", err)
+	}
+	defer source.Close()
+
+	// SPIFFE CONCEPT: Client Authorization
+	// Parse the authorized SPIFFE ID that is allowed to connect to this service.
+	// In the TrustBank demo, this would typically be the customer service's SPIFFE ID.
+	// Only workloads with this exact SPIFFE ID will be accepted.
+	clientID, err := spiffeid.FromString(s.spiffeAuthz)
+	if err != nil {
+		return fmt.Errorf("invalid SPIFFE ID configuration: %w", err)
+	}
+
+	log.Printf("Starting ledger service on %s", s.serverAddress)
+	log.Printf("Authorized SPIFFE ID: %s", clientID.String())
+
+	// SPIFFE CONCEPT: mTLS Server Configuration
+	// MTLSServerConfig creates a TLS configuration for mutual TLS on the server side:
+	//   - First 'source' parameter: provides server certificate to present to clients
+	//   - Second 'source' parameter: provides trust bundles to validate client certificates
+	//   - AuthorizeID(clientID): only accept clients with this exact SPIFFE ID
+	tlsConfig := tlsconfig.MTLSServerConfig(source, source, tlsconfig.AuthorizeID(clientID))
+	server := &http.Server{
+		Addr:              s.serverAddress,
+		Handler:           mux,
+		TLSConfig:         tlsConfig,
+		ReadHeaderTimeout: time.Second * 10,
+	}
+
+	// Start the SPIFFE mTLS server.
+	// Empty strings for cert/key files because TLSConfig already contains our SVID.
+	if err := server.ListenAndServeTLS("", ""); err != nil {
+		return fmt.Errorf("failed to serve: %w", err)
+	}
+	return nil
+}
+
+// StartServer is the entry point called from the CLI command.
+func StartServer(spiffeAuthz, serverAddress string, store Store) {
+	service := NewService(ServiceConfig{
+		ServerAddress: serverAddress,
+		SpiffeAuthz:   spiffeAuthz,
+		Store:         store,
+	})
+
+	if err := service.Run(context.Background()); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/pkg/ledger/store.go
+++ b/pkg/ledger/store.go
@@ -1,0 +1,46 @@
+/*
+Copyright © 2024 Mattias Gees mattias.gees@venafi.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ledger
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+// Store defines the interface for ledger data persistence.
+// This interface allows for easy mocking in tests.
+type Store interface {
+	// GetAccounts returns all accounts.
+	GetAccounts(ctx context.Context) ([]Account, error)
+
+	// GetAccount returns a single account by ID.
+	GetAccount(ctx context.Context, id uuid.UUID) (*Account, error)
+
+	// GetTransactions returns all transactions, ordered by creation time (newest first).
+	GetTransactions(ctx context.Context) ([]Transaction, error)
+
+	// GetTransaction returns a single transaction by ID.
+	GetTransaction(ctx context.Context, id uuid.UUID) (*Transaction, error)
+
+	// CreateTransfer creates a new transfer between accounts.
+	// This operation is atomic - either both accounts are updated or neither is.
+	CreateTransfer(ctx context.Context, req TransferRequest) (*Transaction, error)
+
+	// Close closes the store connection.
+	Close() error
+}

--- a/pkg/ledger/store_test.go
+++ b/pkg/ledger/store_test.go
@@ -1,0 +1,303 @@
+/*
+Copyright © 2024 Mattias Gees mattias.gees@venafi.com
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ledger
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/shopspring/decimal"
+)
+
+var (
+	checkingID = uuid.MustParse("11111111-1111-1111-1111-111111111111")
+	savingsID  = uuid.MustParse("22222222-2222-2222-2222-222222222222")
+)
+
+func TestMockStore_GetAccounts(t *testing.T) {
+	store := NewMockStore()
+	ctx := context.Background()
+
+	accounts, err := store.GetAccounts(ctx)
+	if err != nil {
+		t.Fatalf("GetAccounts() error = %v", err)
+	}
+
+	if len(accounts) != 2 {
+		t.Errorf("Expected 2 accounts, got %d", len(accounts))
+	}
+}
+
+func TestMockStore_GetAccount(t *testing.T) {
+	store := NewMockStore()
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		id      uuid.UUID
+		wantErr error
+	}{
+		{
+			name:    "existing account",
+			id:      checkingID,
+			wantErr: nil,
+		},
+		{
+			name:    "non-existing account",
+			id:      uuid.MustParse("99999999-9999-9999-9999-999999999999"),
+			wantErr: ErrAccountNotFound,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			account, err := store.GetAccount(ctx, tt.id)
+			if err != tt.wantErr {
+				t.Errorf("GetAccount() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr == nil && account == nil {
+				t.Error("GetAccount() returned nil account for existing ID")
+			}
+		})
+	}
+}
+
+func TestMockStore_CreateTransfer(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		request TransferRequest
+		wantErr error
+	}{
+		{
+			name: "valid transfer",
+			request: TransferRequest{
+				FromAccount: checkingID,
+				ToAccount:   savingsID,
+				Amount:      decimal.NewFromFloat(100.00),
+				Description: "Test transfer",
+			},
+			wantErr: nil,
+		},
+		{
+			name: "insufficient funds",
+			request: TransferRequest{
+				FromAccount: checkingID,
+				ToAccount:   savingsID,
+				Amount:      decimal.NewFromFloat(10000.00),
+				Description: "Too much",
+			},
+			wantErr: ErrInsufficientFunds,
+		},
+		{
+			name: "non-existing from account",
+			request: TransferRequest{
+				FromAccount: uuid.MustParse("99999999-9999-9999-9999-999999999999"),
+				ToAccount:   savingsID,
+				Amount:      decimal.NewFromFloat(100.00),
+			},
+			wantErr: ErrAccountNotFound,
+		},
+		{
+			name: "non-existing to account",
+			request: TransferRequest{
+				FromAccount: checkingID,
+				ToAccount:   uuid.MustParse("99999999-9999-9999-9999-999999999999"),
+				Amount:      decimal.NewFromFloat(100.00),
+			},
+			wantErr: ErrAccountNotFound,
+		},
+		{
+			name: "same account",
+			request: TransferRequest{
+				FromAccount: checkingID,
+				ToAccount:   checkingID,
+				Amount:      decimal.NewFromFloat(100.00),
+			},
+			wantErr: ErrSameAccount,
+		},
+		{
+			name: "zero amount",
+			request: TransferRequest{
+				FromAccount: checkingID,
+				ToAccount:   savingsID,
+				Amount:      decimal.Zero,
+			},
+			wantErr: ErrInvalidAmount,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a fresh store for each test
+			store := NewMockStore()
+
+			transaction, err := store.CreateTransfer(ctx, tt.request)
+			if err != tt.wantErr {
+				t.Errorf("CreateTransfer() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.wantErr == nil {
+				if transaction == nil {
+					t.Error("CreateTransfer() returned nil transaction for valid request")
+				} else {
+					if !transaction.Amount.Equal(tt.request.Amount) {
+						t.Errorf("Transaction amount = %s, want %s", transaction.Amount, tt.request.Amount)
+					}
+					if transaction.FromAccount != tt.request.FromAccount {
+						t.Errorf("Transaction FromAccount = %s, want %s", transaction.FromAccount, tt.request.FromAccount)
+					}
+					if transaction.ToAccount != tt.request.ToAccount {
+						t.Errorf("Transaction ToAccount = %s, want %s", transaction.ToAccount, tt.request.ToAccount)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestMockStore_CreateTransfer_UpdatesBalances(t *testing.T) {
+	store := NewMockStore()
+	ctx := context.Background()
+
+	// Get initial balances
+	checkingBefore, _ := store.GetAccount(ctx, checkingID)
+	savingsBefore, _ := store.GetAccount(ctx, savingsID)
+
+	transferAmount := decimal.NewFromFloat(500.00)
+
+	// Perform transfer
+	_, err := store.CreateTransfer(ctx, TransferRequest{
+		FromAccount: checkingID,
+		ToAccount:   savingsID,
+		Amount:      transferAmount,
+	})
+	if err != nil {
+		t.Fatalf("CreateTransfer() error = %v", err)
+	}
+
+	// Check balances after transfer
+	checkingAfter, _ := store.GetAccount(ctx, checkingID)
+	savingsAfter, _ := store.GetAccount(ctx, savingsID)
+
+	expectedCheckingBalance := checkingBefore.Balance.Sub(transferAmount)
+	expectedSavingsBalance := savingsBefore.Balance.Add(transferAmount)
+
+	if !checkingAfter.Balance.Equal(expectedCheckingBalance) {
+		t.Errorf("Checking balance = %s, want %s", checkingAfter.Balance, expectedCheckingBalance)
+	}
+
+	if !savingsAfter.Balance.Equal(expectedSavingsBalance) {
+		t.Errorf("Savings balance = %s, want %s", savingsAfter.Balance, expectedSavingsBalance)
+	}
+}
+
+func TestMockStore_GetTransactions(t *testing.T) {
+	store := NewMockStore()
+	ctx := context.Background()
+
+	// Initially no transactions
+	transactions, err := store.GetTransactions(ctx)
+	if err != nil {
+		t.Fatalf("GetTransactions() error = %v", err)
+	}
+	if len(transactions) != 0 {
+		t.Errorf("Expected 0 transactions, got %d", len(transactions))
+	}
+
+	// Create a transfer
+	_, err = store.CreateTransfer(ctx, TransferRequest{
+		FromAccount: checkingID,
+		ToAccount:   savingsID,
+		Amount:      decimal.NewFromFloat(100.00),
+	})
+	if err != nil {
+		t.Fatalf("CreateTransfer() error = %v", err)
+	}
+
+	// Should now have 1 transaction
+	transactions, err = store.GetTransactions(ctx)
+	if err != nil {
+		t.Fatalf("GetTransactions() error = %v", err)
+	}
+	if len(transactions) != 1 {
+		t.Errorf("Expected 1 transaction, got %d", len(transactions))
+	}
+}
+
+func TestMockStore_GetTransaction(t *testing.T) {
+	store := NewMockStore()
+	ctx := context.Background()
+
+	// Create a transfer
+	created, err := store.CreateTransfer(ctx, TransferRequest{
+		FromAccount: checkingID,
+		ToAccount:   savingsID,
+		Amount:      decimal.NewFromFloat(100.00),
+	})
+	if err != nil {
+		t.Fatalf("CreateTransfer() error = %v", err)
+	}
+
+	// Get the transaction
+	retrieved, err := store.GetTransaction(ctx, created.ID)
+	if err != nil {
+		t.Fatalf("GetTransaction() error = %v", err)
+	}
+
+	if retrieved.ID != created.ID {
+		t.Errorf("GetTransaction() ID = %s, want %s", retrieved.ID, created.ID)
+	}
+
+	// Try to get non-existing transaction
+	_, err = store.GetTransaction(ctx, uuid.MustParse("99999999-9999-9999-9999-999999999999"))
+	if err != ErrTransactionNotFound {
+		t.Errorf("GetTransaction() error = %v, want %v", err, ErrTransactionNotFound)
+	}
+}
+
+func TestMockStore_Reset(t *testing.T) {
+	store := NewMockStore()
+	ctx := context.Background()
+
+	// Make a transfer
+	_, err := store.CreateTransfer(ctx, TransferRequest{
+		FromAccount: checkingID,
+		ToAccount:   savingsID,
+		Amount:      decimal.NewFromFloat(1000.00),
+	})
+	if err != nil {
+		t.Fatalf("CreateTransfer() error = %v", err)
+	}
+
+	// Reset the store
+	store.Reset()
+
+	// Check balances are reset
+	checking, _ := store.GetAccount(ctx, checkingID)
+	if !checking.Balance.Equal(decimal.NewFromFloat(5000.00)) {
+		t.Errorf("After reset, Checking balance = %s, want 5000.00", checking.Balance)
+	}
+
+	// Check transactions are cleared
+	transactions, _ := store.GetTransactions(ctx)
+	if len(transactions) != 0 {
+		t.Errorf("After reset, expected 0 transactions, got %d", len(transactions))
+	}
+}


### PR DESCRIPTION
## Summary

Implements Issue #31 for the TrustBank demo application.

- Add `Service` struct in `pkg/ledger/service.go` with SPIFFE mTLS server configuration
- Implement REST API handlers in `pkg/ledger/handlers.go`:
  - `GET /api/accounts` - List all accounts with balances
  - `GET /api/accounts/{id}` - Get a specific account
  - `POST /api/transfers` - Create transfer between accounts
  - `GET /api/transactions` - List all transactions
  - `GET /api/transactions/{id}` - Get a specific transaction
  - `GET /health` - Health check endpoint
- Add CLI command `spiffe-demo ledger` in `cmd/ledger.go` with:
  - PostgreSQL connection options (host, port, user, database, SSL)
  - Mock store option for development/testing
- Update config structs with ledger-specific configuration
- Comprehensive unit tests for all handlers

## Dependencies

This PR depends on #41 (Issue #30 - Data Models & Database Layer)

## Test plan

- [x] All unit tests pass (`go test ./pkg/ledger/...`)
- [x] Project builds successfully (`go build ./...`)
- [ ] Manual testing with mock store (`./spiffe-demo ledger --use-mock`)
- [ ] Integration test with SPIFFE environment (deferred to integration phase)

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)